### PR TITLE
[codex] update landing page copy for Stellar

### DIFF
--- a/src/components/DiscoverMaterials.jsx
+++ b/src/components/DiscoverMaterials.jsx
@@ -7,6 +7,7 @@ import { FiFilter } from "react-icons/fi";
 
 export default function DiscoverMaterials() {
 	const [loading, setLoading] = useState(true);
+	const priceUnit = "XLM";
 
     const imageOptions = [
         "/images/Generated Image November 07, 2025 - 6_44AM.png",
@@ -18,7 +19,7 @@ export default function DiscoverMaterials() {
             title: "CHM 112 – Lab Report Template (UNN)",
             author: "Chijioke M.",
             likes: "21.5K",
-            bid: "0.25 CELO",
+            bid: `0.25 ${priceUnit}`,
             time: "01:09:40",
             image: imageOptions[Math.floor(Math.random() * imageOptions.length)],
         })),

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -5,6 +5,8 @@ import Link from "next/link";
 import { motion } from "framer-motion";
 
 export default function Hero() {
+	const networkName = "Stellar";
+
 	const fadeUp = {
 		hidden: { opacity: 0, y: 40 },
 		show: { opacity: 1, y: 0, transition: { duration: 0.8, ease: "easeOut" } },
@@ -64,8 +66,9 @@ export default function Hero() {
 					variants={fadeUp}
 					className="text-gray-600 max-w-2xl text-sm md:text-base mb-8"
 				>
-					Upload your study materials, past exam papers, and reports — mint them
-					as NFTs, share with others, and get rewarded when they’re downloaded.
+					Upload your study materials, past exam papers, and reports with
+					Stellar-backed ownership, share with others, and get rewarded when
+					they’re unlocked.
 				</motion.p>
 
 				{/* CTA Buttons */}
@@ -90,16 +93,15 @@ export default function Hero() {
 					className="relative mt-8 flex items-center justify-center"
 				>
 					<motion.div
-						className="absolute -left-16 top-10 w-16 h-16 rounded-full  flex items-center justify-center rotate-12"
+						className="absolute -left-16 top-10 rotate-12"
 						animate={{ y: [0, -10, 0] }}
 						transition={{ repeat: Infinity, duration: 3, ease: "easeInOut" }}
 					>
-						<Image
-						src="/images/celo.png"
-						alt="cele Icon"
-						width={80}
-						height={80}
-					/>
+						<div className="flex h-20 w-20 items-center justify-center rounded-full border border-sky-200 bg-white/90 shadow-lg shadow-sky-100">
+							<span className="text-xs font-semibold uppercase tracking-[0.3em] text-sky-700">
+								{networkName}
+							</span>
+						</div>
 					</motion.div>
 
 					<motion.div
@@ -132,7 +134,7 @@ export default function Hero() {
 
 				{/* Footer Text */}
 				<motion.p variants={fadeUp} className="text-xs text-gray-500 mt-10">
-					Supported by Students. Powered by Blockchain.
+					Supported by Students. Powered by {networkName}.
 				</motion.p>
 
 			{/* Partner Logos */}

--- a/src/components/TopSharedMaterials.jsx
+++ b/src/components/TopSharedMaterials.jsx
@@ -5,20 +5,23 @@ import { motion } from "framer-motion";
 import { FaCrown } from "react-icons/fa";
 
 export default function TopSharedMaterials() {
+	const networkName = "Stellar";
+	const priceUnit = "XLM";
+
 	const sharedMaterials = [
 		{
 			title: "CHM 112 – Lab Report (Year 1)",
-			price: "0.25 CELO",
+			price: `0.25 ${priceUnit}`,
 			authorImg: "/author1.png",
 		},
 		{
 			title: "GNS 201 – Use of English (Year 2)",
-			price: "0.25 CELO",
+			price: `0.25 ${priceUnit}`,
 			authorImg: "/author2.png",
 		},
 		{
 			title: "CSC 301 – Data Structures (Year 3)",
-			price: "0.26 CELO",
+			price: `0.26 ${priceUnit}`,
 			authorImg: "/author3.png",
 		},
 	];
@@ -27,35 +30,35 @@ export default function TopSharedMaterials() {
 		{
 			rank: 1,
 			name: "CryptoFunks",
-			price: "0.25 CELO",
+			price: `0.25 ${priceUnit}`,
 			change: "+26.52%",
 			color: "text-green-500",
 		},
 		{
 			rank: 2,
 			name: "Cryptix",
-			price: "0.25 CELO",
+			price: `0.25 ${priceUnit}`,
 			change: "+10.52%",
 			color: "text-red-500",
 		},
 		{
 			rank: 3,
 			name: "Frenesware",
-			price: "0.25 CELO",
+			price: `0.25 ${priceUnit}`,
 			change: "+5.52%",
 			color: "text-green-500",
 		},
 		{
 			rank: 4,
 			name: "PunkArt",
-			price: "50,008 CELO",
+			price: `50,008 ${priceUnit}`,
 			change: "+1.52%",
 			color: "text-green-500",
 		},
 		{
 			rank: 5,
 			name: "Art Crypto",
-			price: "4,524 CELO",
+			price: `4,524 ${priceUnit}`,
 			change: "+2.52%",
 			color: "text-red-500",
 		},
@@ -123,15 +126,11 @@ export default function TopSharedMaterials() {
 							</p>
 						</div>
 						<div className="flex items-center gap-1">
-							<Image
-								src="/celo.png"
-								alt="CELO"
-								width={18}
-								height={18}
-								className="rounded-full"
-							/>
+							<span className="inline-flex rounded-full border border-sky-200 bg-sky-50 px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.2em] text-sky-700">
+								{networkName}
+							</span>
 							<span className="text-xs font-semibold text-gray-700">
-								0.25 CELO
+								0.25 {priceUnit}
 							</span>
 						</div>
 					</div>
@@ -163,12 +162,9 @@ export default function TopSharedMaterials() {
 										{material.title}
 									</h3>
 									<div className="flex items-center gap-2 mt-1">
-										<Image
-											src="/celo.png"
-											alt="CELO"
-											width={14}
-											height={14}
-										/>
+										<span className="inline-flex rounded-full border border-sky-200 bg-sky-50 px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.2em] text-sky-700">
+											{networkName}
+										</span>
 										<span className="text-xs font-medium text-gray-600">
 											{material.price}
 										</span>


### PR DESCRIPTION
## What changed
- replaced legacy Celo-branded landing-page copy with Stellar/XLM language
- removed the visible Celo token icon from the landing hero and replaced it with a Stellar badge so the UI no longer shows mismatched chain branding
- updated landing-page pricing labels in `TopSharedMaterials` and `DiscoverMaterials` from `CELO` to `XLM`

## Why
The repo has already been repositioned around Stellar, but the landing page still exposed Celo-era naming and visuals. That made the first impression inconsistent with the current product direction.

## Impact
- visitors landing on `/` now see Stellar-first branding instead of mixed chain messaging
- contributors now have dedicated UI/UX redesign issues for the core routes:
  - #16 landing page redesign
  - #17 marketplace redesign
  - #18 material detail redesign
  - #19 dashboard home redesign
  - #20 upload flow redesign

## Validation
- reviewed the scoped diff in a clean clone based on `main`
- ran `git diff --check`

## Notes
This PR intentionally keeps the code change narrow to the landing experience and avoids bundling the unrelated local modifications present in the original checkout.