### PR TITLE
fix(smart-contract): harden _ownedTokens bookkeeping with O(1) transfers

### DIFF
--- a/contracts/EduVault.sol
+++ b/contracts/EduVault.sol
@@ -3,15 +3,41 @@ pragma solidity ^0.8.24;
 
 import "@openzeppelin/contracts/token/ERC721/extensions/ERC721URIStorage.sol";
 
+/**
+ * @title EduVault
+ * @notice NFT contract for educational content marketplace
+ * @dev Extends ERC721URIStorage with manual ownership enumeration via _ownedTokens.
+ *
+ * OWNERSHIP ENUMERATION TRADEOFF:
+ * - The _ownedTokens mapping maintains a list of token IDs per owner for efficient
+ *   off-chain queries (e.g., "show all materials owned by user X").
+ * - Removal from the list uses O(n) linear scan on transfers, which is acceptable
+ *   because:
+ *   1. Educational material NFTs are rarely transferred after minting
+ *   2. Typical user token counts are small (< 100)
+ *   3. Gas costs remain reasonable for expected usage patterns
+ *   4. No external enumeration standard (like ERC721Enumerable) is required
+ * - For high-transfer-volume use cases, consider replacing with ERC721Enumerable
+ *   or an off-chain indexer.
+ */
 contract EduVault is ERC721URIStorage {
     uint256 private _nextTokenId;
 
     // Mapping from owner to list of owned token IDs
+    // INVARIANT: For each address `owner`, _ownedTokens[owner] contains exactly
+    // the set of non-burned token IDs where ownerOf(tokenId) == owner.
     mapping(address => uint256[]) private _ownedTokens;
+
+    // Track position of each token in owner's array for O(1) removal
+    // INVARIANT: _ownedTokensIndex[tokenId] is the index in _ownedTokens[ownerOf(tokenId)]
+    mapping(uint256 => uint256) private _ownedTokensIndex;
 
     constructor() ERC721("EduVault", "EDV") {}
 
-    // Allow anyone to mint their own NFT
+    /**
+     * @notice Mint a new educational material NFT
+     * @param uri IPFS or HTTP URI pointing to material metadata
+     */
     function mint(string memory uri) external {
         uint256 tokenId = _nextTokenId;
         _nextTokenId += 1;
@@ -20,12 +46,33 @@ contract EduVault is ERC721URIStorage {
         _setTokenURI(tokenId, uri);
     }
 
-    // Get all token IDs owned by a specific address
+    /**
+     * @notice Get all token IDs owned by a specific address
+     * @param owner Address to query
+     * @return Array of token IDs owned by the address
+     */
     function tokensOfOwner(address owner) external view returns (uint256[] memory) {
         return _ownedTokens[owner];
     }
 
-    // Override to clean up ownership tracking when transferring
+    /**
+     * @notice Get total number of tokens minted
+     * @return Total minted token count
+     */
+    function totalMinted() external view returns (uint256) {
+        return _nextTokenId;
+    }
+
+    /**
+     * @dev Override to maintain ownership enumeration on transfers.
+     * Uses O(1) removal via index tracking instead of O(n) scan.
+     *
+     * INVARIANTS MAINTAINED:
+     * - After transfer, old owner's list no longer contains tokenId
+     * - After transfer, new owner's list contains tokenId at correct index
+     * - Index mapping is updated to reflect new position
+     * - Zero-address transfers (burns) properly clean up ownership list
+     */
     function _update(address to, uint256 tokenId, address auth)
         internal
         override
@@ -34,19 +81,28 @@ contract EduVault is ERC721URIStorage {
         address from = super._update(to, tokenId, auth);
 
         if (from != address(0)) {
-            // remove token from old owner list
+            // Remove token from old owner list using O(1) swap-and-pop
             uint256[] storage fromTokens = _ownedTokens[from];
-            for (uint256 i = 0; i < fromTokens.length; i++) {
-                if (fromTokens[i] == tokenId) {
-                    fromTokens[i] = fromTokens[fromTokens.length - 1];
-                    fromTokens.pop();
-                    break;
-                }
+            uint256 tokenIndex = _ownedTokensIndex[tokenId];
+            uint256 lastIndex = fromTokens.length - 1;
+
+            // If the token is not the last one, swap it with the last token
+            if (tokenIndex != lastIndex) {
+                uint256 lastTokenId = fromTokens[lastIndex];
+                fromTokens[tokenIndex] = lastTokenId;
+                _ownedTokensIndex[lastTokenId] = tokenIndex; // Update index of moved token
             }
+
+            // Remove the last element and clean up index
+            fromTokens.pop();
+            delete _ownedTokensIndex[tokenId];
         }
 
         if (to != address(0)) {
+            // Add token to new owner list
+            uint256 newIndex = _ownedTokens[to].length;
             _ownedTokens[to].push(tokenId);
+            _ownedTokensIndex[tokenId] = newIndex;
         }
 
         return from;

--- a/tests/contracts/EduVault.test.js
+++ b/tests/contracts/EduVault.test.js
@@ -3,37 +3,271 @@ const { ethers } = require("hardhat");
 
 describe("EduVault", function () {
   async function deployVault() {
-    const [creator, buyer] = await ethers.getSigners();
+    const [creator, buyer, receiver, ...others] = await ethers.getSigners();
     const EduVault = await ethers.getContractFactory("EduVault");
     const vault = await EduVault.deploy();
     await vault.waitForDeployment();
 
-    return { buyer, creator, vault };
+    return { buyer, creator, others, receiver, vault };
   }
 
   function tokenIds(values) {
     return values.map((value) => Number(value));
   }
 
-  it("mints a token and stores its tokenURI", async function () {
-    const { creator, vault } = await deployVault();
-    const uri = "ipfs://eduvault/material-1";
+  describe("minting", function () {
+    it("mints a token and stores its tokenURI", async function () {
+      const { creator, vault } = await deployVault();
+      const uri = "ipfs://eduvault/material-1";
 
-    await vault.connect(creator).mint(uri);
+      await vault.connect(creator).mint(uri);
 
-    assert.equal(await vault.ownerOf(0), creator.address);
-    assert.equal(await vault.tokenURI(0), uri);
-    assert.deepEqual(tokenIds(await vault.tokensOfOwner(creator.address)), [0]);
+      assert.equal(await vault.ownerOf(0), creator.address);
+      assert.equal(await vault.tokenURI(0), uri);
+      assert.deepEqual(tokenIds(await vault.tokensOfOwner(creator.address)), [0]);
+    });
+
+    it("mints multiple tokens with sequential IDs", async function () {
+      const { creator, vault } = await deployVault();
+
+      await vault.connect(creator).mint("ipfs://eduvault/material-1");
+      await vault.connect(creator).mint("ipfs://eduvault/material-2");
+      await vault.connect(creator).mint("ipfs://eduvault/material-3");
+
+      assert.equal(await vault.ownerOf(0), creator.address);
+      assert.equal(await vault.ownerOf(1), creator.address);
+      assert.equal(await vault.ownerOf(2), creator.address);
+      assert.deepEqual(
+        tokenIds(await vault.tokensOfOwner(creator.address)),
+        [0, 1, 2]
+      );
+      assert.equal(Number(await vault.totalMinted()), 3);
+    });
+
+    it("allows different users to mint independently", async function () {
+      const { creator, buyer, vault } = await deployVault();
+
+      await vault.connect(creator).mint("ipfs://eduvault/material-1");
+      await vault.connect(buyer).mint("ipfs://eduvault/material-2");
+
+      assert.equal(await vault.ownerOf(0), creator.address);
+      assert.equal(await vault.ownerOf(1), buyer.address);
+      assert.deepEqual(tokenIds(await vault.tokensOfOwner(creator.address)), [0]);
+      assert.deepEqual(tokenIds(await vault.tokensOfOwner(buyer.address)), [1]);
+    });
   });
 
-  it("updates owner token enumeration after transfers", async function () {
-    const { buyer, creator, vault } = await deployVault();
+  describe("transfers", function () {
+    it("updates owner token enumeration after transfers", async function () {
+      const { buyer, creator, vault } = await deployVault();
 
-    await vault.connect(creator).mint("ipfs://eduvault/material-1");
-    await vault.connect(creator).transferFrom(creator.address, buyer.address, 0);
+      await vault.connect(creator).mint("ipfs://eduvault/material-1");
+      await vault.connect(creator).transferFrom(creator.address, buyer.address, 0);
 
-    assert.deepEqual(tokenIds(await vault.tokensOfOwner(creator.address)), []);
-    assert.deepEqual(tokenIds(await vault.tokensOfOwner(buyer.address)), [0]);
-    assert.equal(await vault.ownerOf(0), buyer.address);
+      assert.deepEqual(tokenIds(await vault.tokensOfOwner(creator.address)), []);
+      assert.deepEqual(tokenIds(await vault.tokensOfOwner(buyer.address)), [0]);
+      assert.equal(await vault.ownerOf(0), buyer.address);
+    });
+
+    it("handles repeated transfers correctly", async function () {
+      const { buyer, creator, receiver, vault } = await deployVault();
+
+      await vault.connect(creator).mint("ipfs://eduvault/material-1");
+      
+      // Transfer to buyer
+      await vault.connect(creator).transferFrom(creator.address, buyer.address, 0);
+      assert.deepEqual(tokenIds(await vault.tokensOfOwner(creator.address)), []);
+      assert.deepEqual(tokenIds(await vault.tokensOfOwner(buyer.address)), [0]);
+
+      // Transfer to receiver
+      await vault.connect(buyer).transferFrom(buyer.address, receiver.address, 0);
+      assert.deepEqual(tokenIds(await vault.tokensOfOwner(buyer.address)), []);
+      assert.deepEqual(tokenIds(await vault.tokensOfOwner(receiver.address)), [0]);
+
+      // Transfer back to creator
+      await vault.connect(receiver).transferFrom(receiver.address, creator.address, 0);
+      assert.deepEqual(tokenIds(await vault.tokensOfOwner(receiver.address)), []);
+      assert.deepEqual(tokenIds(await vault.tokensOfOwner(creator.address)), [0]);
+    });
+
+    it("maintains correct enumeration with multiple tokens and transfers", async function () {
+      const { buyer, creator, vault } = await deployVault();
+
+      // Creator mints 3 tokens
+      await vault.connect(creator).mint("ipfs://material-1");
+      await vault.connect(creator).mint("ipfs://material-2");
+      await vault.connect(creator).mint("ipfs://material-3");
+
+      assert.deepEqual(
+        tokenIds(await vault.tokensOfOwner(creator.address)),
+        [0, 1, 2]
+      );
+
+      // Transfer middle token (1) to buyer
+      await vault.connect(creator).transferFrom(creator.address, buyer.address, 1);
+      assert.deepEqual(
+        tokenIds(await vault.tokensOfOwner(creator.address)).sort(),
+        [0, 2]
+      );
+      assert.deepEqual(tokenIds(await vault.tokensOfOwner(buyer.address)), [1]);
+
+      // Transfer first token (0) to buyer
+      await vault.connect(creator).transferFrom(creator.address, buyer.address, 0);
+      assert.deepEqual(tokenIds(await vault.tokensOfOwner(creator.address)), [2]);
+      assert.deepEqual(
+        tokenIds(await vault.tokensOfOwner(buyer.address)).sort(),
+        [0, 1]
+      );
+    });
+
+    it("handles safeTransferFrom correctly", async function () {
+      const { buyer, creator, vault } = await deployVault();
+
+      await vault.connect(creator).mint("ipfs://eduvault/material-1");
+      await vault.connect(creator).safeTransferFrom(creator.address, buyer.address, 0);
+
+      assert.deepEqual(tokenIds(await vault.tokensOfOwner(creator.address)), []);
+      assert.deepEqual(tokenIds(await vault.tokensOfOwner(buyer.address)), [0]);
+      assert.equal(await vault.ownerOf(0), buyer.address);
+    });
+  });
+
+  describe("edge cases", function () {
+    it("handles transfers to and from zero-address correctly", async function () {
+      const { creator, vault } = await deployVault();
+
+      await vault.connect(creator).mint("ipfs://eduvault/material-1");
+      
+      // Verify token exists and is owned by creator
+      assert.equal(await vault.ownerOf(0), creator.address);
+      assert.deepEqual(tokenIds(await vault.tokensOfOwner(creator.address)), [0]);
+
+      // Attempting to transfer to zero address should revert in ERC721
+      await assert.rejects(
+        vault.connect(creator).transferFrom(creator.address, ethers.ZeroAddress, 0),
+        /ERC721InvalidReceiver/
+      );
+
+      // Creator should still own the token
+      assert.equal(await vault.ownerOf(0), creator.address);
+      assert.deepEqual(tokenIds(await vault.tokensOfOwner(creator.address)), [0]);
+    });
+
+    it("prevents transfer of non-existent token", async function () {
+      const { buyer, creator, vault } = await deployVault();
+
+      await assert.rejects(
+        vault.connect(creator).transferFrom(creator.address, buyer.address, 999),
+        /ERC721NonexistentToken/
+      );
+    });
+
+    it("prevents unauthorized transfers", async function () {
+      const { buyer, creator, vault } = await deployVault();
+
+      await vault.connect(creator).mint("ipfs://eduvault/material-1");
+
+      await assert.rejects(
+        vault.connect(buyer).transferFrom(creator.address, buyer.address, 0),
+      );
+
+      // Creator should still own the token
+      assert.equal(await vault.ownerOf(0), creator.address);
+      assert.deepEqual(tokenIds(await vault.tokensOfOwner(creator.address)), [0]);
+    });
+
+    it("handles rapid successive transfers of same token", async function () {
+      const { buyer, creator, others, receiver, vault } = await deployVault();
+
+      await vault.connect(creator).mint("ipfs://eduvault/material-1");
+
+      // Rapid transfers
+      await vault.connect(creator).transferFrom(creator.address, buyer.address, 0);
+      await vault.connect(buyer).transferFrom(buyer.address, receiver.address, 0);
+      await vault.connect(receiver).transferFrom(receiver.address, others[0].address, 0);
+
+      assert.deepEqual(tokenIds(await vault.tokensOfOwner(creator.address)), []);
+      assert.deepEqual(tokenIds(await vault.tokensOfOwner(buyer.address)), []);
+      assert.deepEqual(tokenIds(await vault.tokensOfOwner(receiver.address)), []);
+      assert.deepEqual(tokenIds(await vault.tokensOfOwner(others[0].address)), [0]);
+      assert.equal(await vault.ownerOf(0), others[0].address);
+    });
+
+    it("maintains invariants after multiple mints and transfers", async function () {
+      const { buyer, creator, others, receiver, vault } = await deployVault();
+
+      // Multiple users mint tokens
+      await vault.connect(creator).mint("ipfs://m1");
+      await vault.connect(creator).mint("ipfs://m2");
+      await vault.connect(buyer).mint("ipfs://m3");
+      await vault.connect(buyer).mint("ipfs://m4");
+      await vault.connect(others[0]).mint("ipfs://m5");
+
+      // Verify initial state
+      assert.deepEqual(
+        tokenIds(await vault.tokensOfOwner(creator.address)),
+        [0, 1]
+      );
+      assert.deepEqual(
+        tokenIds(await vault.tokensOfOwner(buyer.address)),
+        [2, 3]
+      );
+      assert.deepEqual(
+        tokenIds(await vault.tokensOfOwner(others[0].address)),
+        [4]
+      );
+
+      // Perform various transfers
+      await vault.connect(creator).transferFrom(creator.address, buyer.address, 0);
+      await vault.connect(buyer).transferFrom(buyer.address, receiver.address, 2);
+      await vault.connect(others[0]).transferFrom(others[0].address, creator.address, 4);
+
+      // Verify final state
+      assert.deepEqual(
+        tokenIds(await vault.tokensOfOwner(creator.address)).sort(),
+        [1, 4]
+      );
+      assert.deepEqual(
+        tokenIds(await vault.tokensOfOwner(buyer.address)).sort(),
+        [0, 3]
+      );
+      assert.deepEqual(tokenIds(await vault.tokensOfOwner(receiver.address)), [2]);
+      assert.deepEqual(tokenIds(await vault.tokensOfOwner(others[0].address)), []);
+
+      // Verify ownership via ownerOf
+      assert.equal(await vault.ownerOf(0), buyer.address);
+      assert.equal(await vault.ownerOf(1), creator.address);
+      assert.equal(await vault.ownerOf(2), receiver.address);
+      assert.equal(await vault.ownerOf(3), buyer.address);
+      assert.equal(await vault.ownerOf(4), creator.address);
+    });
+  });
+
+  describe("totalMinted", function () {
+    it("returns correct count after multiple mints", async function () {
+      const { creator, buyer, vault } = await deployVault();
+
+      assert.equal(Number(await vault.totalMinted()), 0);
+
+      await vault.connect(creator).mint("ipfs://m1");
+      assert.equal(Number(await vault.totalMinted()), 1);
+
+      await vault.connect(buyer).mint("ipfs://m2");
+      assert.equal(Number(await vault.totalMinted()), 2);
+
+      await vault.connect(creator).mint("ipfs://m3");
+      assert.equal(Number(await vault.totalMinted()), 3);
+    });
+
+    it("totalMinted is not affected by transfers", async function () {
+      const { buyer, creator, vault } = await deployVault();
+
+      await vault.connect(creator).mint("ipfs://m1");
+      await vault.connect(creator).mint("ipfs://m2");
+      assert.equal(Number(await vault.totalMinted()), 2);
+
+      await vault.connect(creator).transferFrom(creator.address, buyer.address, 0);
+      assert.equal(Number(await vault.totalMinted()), 2);
+    });
   });
 });


### PR DESCRIPTION
- Replace O(n) linear scan with O(1) swap-and-pop using index tracking
- Add _ownedTokensIndex mapping for constant-time token position lookup
- Add comprehensive NatSpec documentation explaining tradeoffs
- Add 12 new test cases covering edge cases:
  * Multiple mints and sequential IDs
  * Repeated transfers between multiple addresses
  * SafeTransferFrom handling
  * Zero-address transfer prevention
  * Unauthorized transfer prevention
  * Rapid successive transfers
  * Complex multi-token ownership invariants
  * totalMinted function verification

Fixes #13

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a public function to query the total number of minted tokens.

* **Improvements**
  * Enhanced the efficiency of token ownership enumeration operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->