### PR TITLE
feat(dashboard): refactor My Materials to use canonical records 

### DIFF
--- a/src/app/dashboard/my-materials/page.jsx
+++ b/src/app/dashboard/my-materials/page.jsx
@@ -1,133 +1,53 @@
 "use client";
 
-import { useEffect, useState, useMemo } from "react";
-import { useAccount, useReadContract, useReadContracts } from "wagmi";
-import { abi } from "../../../../contracts/EduVaultAbi";
-import { celoSepolia } from "wagmi/chains";
+import { useEffect, useState } from "react";
+import { useAccount } from "wagmi";
 
-const contractAddress = "0x3f48520ca0d8d51345b416b5a3e083dac8790f55";
-
+/**
+ * MyMaterialsPage
+ * Renders the creator's materials sourced from the canonical backend record.
+ * This replaces the fragile client-side deduplication and NFT metadata reconstruction.
+ */
 export default function MyMaterialsPage() {
   const { address } = useAccount();
-  const [nfts, setNfts] = useState([]);
+  const [materials, setMaterials] = useState([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
 
-  // 1️⃣ Fetch all token IDs owned by this wallet
-  const {
-    data: tokenIdsData,
-    isLoading: tokensLoading,
-    isError: tokensError,
-  } = useReadContract({
-    address: contractAddress,
-    abi,
-    functionName: "tokensOfOwner",
-    args: [address ?? "0x0000000000000000000000000000000000000000"],
-    chain: celoSepolia,
-    enabled: Boolean(address),
-  });
-
-  // Normalize token IDs to strings
-  const tokenIds = useMemo(() => {
-    if (!tokenIdsData || tokenIdsData.length === 0) return [];
-    return tokenIdsData.map((id) => id.toString());
-  }, [tokenIdsData]);
-
-  // 2️⃣ Fetch tokenURI for each token ID
-  const tokenUriCalls = useMemo(() => {
-    if (!tokenIds || tokenIds.length === 0) return [];
-    return tokenIds.map((id) => ({
-      address: contractAddress,
-      abi,
-      functionName: "tokenURI",
-      args: [id],
-      chain: celoSepolia,
-    }));
-  }, [tokenIds]);
-
-  const {
-    data: tokenUriResults,
-    isLoading: uriLoading,
-    isError: uriError,
-  } = useReadContracts({
-    contracts: tokenUriCalls,
-    enabled: tokenUriCalls.length > 0,
-  });
-
-  // 3️⃣ Fetch metadata JSON for each valid HTTPS URI
   useEffect(() => {
-    if (!address || !tokenUriResults || tokenUriResults.length === 0) return;
+    if (!address) return;
     let mounted = true;
 
-    const fetchMetadata = async () => {
+    const fetchMaterials = async () => {
       setLoading(true);
       setError(null);
       try {
-        const fetched = await Promise.all(
-          tokenUriResults.map(async (entry, idx) => {
-            if (!entry || entry.status !== "success") return null;
+        // Fetch canonical records for the connected wallet
+        const res = await fetch("/api/materials", { cache: "no-store" });
+        if (!res.ok) {
+          if (res.status === 401) {
+            throw new Error("Please sign in to view your materials.");
+          }
+          throw new Error("Failed to fetch materials from the canonical record.");
+        }
+        const data = await res.json();
 
-            const uri = Array.isArray(entry.result)
-              ? entry.result[0]
-              : entry.result;
-
-            // only accept https:// URIs
-            if (!uri || !uri.startsWith("https://")) return null;
-            const url = uri;
-
-            try {
-              const res = await fetch(url, { cache: "no-store" });
-              if (!res.ok) throw new Error(`Failed to fetch ${url}`);
-              const json = await res.json();
-
-              // filter only valid https:// URLs for file and image
-              const image =
-                json.image?.startsWith("https://") ? json.image : null;
-              const fileUrl =
-                json.file?.startsWith("https://")
-                  ? json.file
-                  : json.animation_url?.startsWith("https://")
-                    ? json.animation_url
-                    : null;
-
-              return {
-                name: json.name || "Untitled NFT",
-                description: json.description || "",
-                price: json.price || "0",
-                visibility: json.visibility || "private",
-                image,
-                fileUrl,
-                timestamp: json.timestamp,
-              };
-            } catch (err) {
-              console.error("Metadata fetch failed:", err);
-              return null;
-            }
-          })
-        );
         if (mounted) {
-          // filter out duplicate tokenIds
-          const unique = fetched
-            .filter(Boolean)
-            .filter(
-              (nft, index, self) =>
-                index === self.findIndex((t) => t.name === nft.name && t.fileUrl === nft.fileUrl)
-            );
-          setNfts(unique);
+          setMaterials(data);
         }
       } catch (err) {
-        console.error(err);
-        setError("Failed to fetch NFT metadata");
+        console.error("Error fetching materials:", err);
+        if (mounted) setError(err.message || "Error loading materials.");
       } finally {
         if (mounted) setLoading(false);
       }
     };
 
-    fetchMetadata();
+    fetchMaterials();
     return () => {
       mounted = false;
     };
-  }, [tokenUriResults, address, tokenIds]);
+  }, [address]);
 
   // Helper: format date like “Nov 02, 2025”
   const formatDate = (timestamp) => {
@@ -140,96 +60,123 @@ export default function MyMaterialsPage() {
     });
   };
 
-
   // 🧩 UI States
   if (!address)
     return (
-      <div className="min-h-screen flex items-center justify-center">
+      <div className="min-h-screen flex items-center justify-center bg-gray-50">
         <p className="text-gray-600 text-sm">
-          Connect your wallet to view your minted NFTs.
+          Connect your wallet to view your minted materials.
         </p>
       </div>
     );
 
-  if (tokensLoading || uriLoading || loading)
+  if (loading)
     return (
-      <div className="min-h-screen flex items-center justify-center">
-        <p className="text-gray-600 text-sm">Loading your materials...</p>
+      <div className="min-h-screen flex items-center justify-center bg-gray-50">
+        <div className="flex flex-col items-center gap-2">
+          <div className="w-6 h-6 border-2 border-blue-600 border-t-transparent rounded-full animate-spin"></div>
+          <p className="text-gray-600 text-sm">Loading your materials...</p>
+        </div>
       </div>
     );
 
-  if (tokensError || uriError || error)
+  if (error)
     return (
-      <div className="min-h-screen flex items-center justify-center">
-        <p className="text-red-600 text-sm">{error || "Error loading NFTs."}</p>
+      <div className="min-h-screen flex items-center justify-center bg-gray-50">
+        <p className="text-red-600 text-sm">{error}</p>
       </div>
     );
 
-  // 🖼️ NFT Grid
+  // 🖼️ Material Grid
   return (
     <div className="min-h-screen bg-gray-50 text-gray-900">
       <div className="max-w-6xl mx-auto py-10 px-6">
-        <h1 className="text-2xl font-bold mb-6">My Minted NFTs</h1>
+        <div className="flex items-center justify-between mb-8">
+          <h1 className="text-2xl font-bold">My Materials</h1>
+          <span className="text-xs font-medium bg-blue-100 text-blue-700 px-2 py-1 rounded-md">
+            {materials.length} Items
+          </span>
+        </div>
 
-        {(!nfts || nfts.length === 0) ? (
-          <p className="text-sm text-gray-600">No NFTs found for this wallet.</p>
+        {(!materials || materials.length === 0) ? (
+          <div className="bg-white border border-gray-200 rounded-2xl p-12 text-center shadow-sm">
+            <p className="text-sm text-gray-600 mb-4">No materials found for this wallet.</p>
+            <a 
+              href="/dashboard/upload" 
+              className="text-blue-600 hover:underline text-sm font-medium"
+            >
+              Upload your first material
+            </a>
+          </div>
         ) : (
           <ul className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
-            {nfts.map((nft, index) => (
+            {materials.map((item) => (
               <li
-                key={index}
-                className="bg-white border border-gray-200 rounded-2xl p-4 shadow-sm hover:shadow-md transition-all"
+                key={item._id || item.materialId}
+                className="bg-white border border-gray-200 rounded-2xl overflow-hidden shadow-sm hover:shadow-md transition-all flex flex-col"
               >
-                {nft.image && (
-                  <img
-                    src={nft.image}
-                    alt={nft.name}
-                    className="w-full h-44 object-cover rounded-lg mb-4"
-                  />
-                )}
-                <h3 className="text-lg font-semibold mb-1">{nft.name}</h3>
-                {nft.description && (
-                  <p className="text-sm text-gray-600 mb-3 line-clamp-2">
-                    {nft.description}
-                  </p>
-                )}
-                <div className="space-y-1 text-sm">
-                  <p>
-                    <span className="font-medium text-gray-700">Price:</span>{" "}
-                    <span className="text-gray-800">
-                      ₦{nft.price}
+                {/* Thumbnail */}
+                <div className="relative h-44 bg-gray-100">
+                  {item.thumbnailUrl ? (
+                    <img
+                      src={item.thumbnailUrl}
+                      alt={item.title}
+                      className="w-full h-full object-cover"
+                    />
+                  ) : (
+                    <div className="w-full h-full flex items-center justify-center text-gray-400">
+                      <span className="text-xs">No preview available</span>
+                    </div>
+                  )}
+                  <div className="absolute top-3 right-3">
+                    <span className={`text-[10px] uppercase font-bold px-2 py-1 rounded-full shadow-sm ${
+                      item.visibility === 'public' ? 'bg-green-100 text-green-700' : 'bg-gray-100 text-gray-700'
+                    }`}>
+                      {item.visibility}
                     </span>
-                  </p>
-                  <p>
-                    <span className="font-medium text-gray-700">
-                      Visibility:
-                    </span>{" "}
-                    <span className="capitalize text-gray-800">
-                      {nft.visibility}
-                    </span>
-                  </p>
-                  <p>
-                    <span className="font-medium text-gray-700">
-                      Date Minted:
-                    </span>{" "}
-                    <span className="text-gray-800">
-                      {formatDate(nft.timestamp)}
-                    </span>
-                  </p>
+                  </div>
                 </div>
 
-                {nft.fileUrl && (
-                  <div className="mt-4">
-                    <a
-                      href={nft.fileUrl}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="inline-block w-full text-center bg-blue-600 hover:bg-blue-700 text-white py-2 px-3 rounded-lg font-medium transition-all"
-                    >
-                      View File
-                    </a>
+                {/* Content */}
+                <div className="p-5 flex-1 flex flex-col">
+                  <h3 className="text-lg font-semibold mb-2 line-clamp-1" title={item.title}>
+                    {item.title}
+                  </h3>
+                  {item.description && (
+                    <p className="text-sm text-gray-600 mb-4 line-clamp-2 flex-1">
+                      {item.description}
+                    </p>
+                  )}
+                  
+                  <div className="space-y-2 pt-4 border-t border-gray-50">
+                    <div className="flex justify-between items-center text-sm">
+                      <span className="text-gray-500">Price</span>
+                      <span className="font-semibold text-gray-900">
+                        {item.price > 0 ? `${item.price} CELO` : "Free"}
+                      </span>
+                    </div>
+                    
+                    <div className="flex justify-between items-center text-sm">
+                      <span className="text-gray-500">Created</span>
+                      <span className="text-gray-700">
+                        {formatDate(item.createdAt)}
+                      </span>
+                    </div>
                   </div>
-                )}
+
+                  {item.fileUrl && (
+                    <div className="mt-5">
+                      <a
+                        href={item.fileUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-block w-full text-center bg-blue-600 hover:bg-blue-700 text-white py-2 rounded-lg text-sm font-medium transition-all"
+                      >
+                        View Material
+                      </a>
+                    </div>
+                  )}
+                </div>
               </li>
             ))}
           </ul>
@@ -237,4 +184,4 @@ export default function MyMaterialsPage() {
       </div>
     </div>
   );
-}
+}


### PR DESCRIPTION
**Summary**:

This pr closes #14 

This PR resolves the P1 issue where the "My Materials" page was using fragile client-side deduplication heuristics and reconstructing state from NFT metadata. The page now sources data directly from the canonical material records in the backend database.

**Key Changes**:
- **Data Fetching**: Switched from direct contract reads to `/api/materials` endpoint.
- **Deduplication**: Removed fragile name+fileUrl client-side deduplication.
- **Schema**: Aligned rendering with the `materials` collection schema.
- **Price Formatting**: Corrected unit display to use `CELO`.
- **States**: Improved empty, loading, and error state handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Materials section now displays enhanced information including creation date, pricing, and visibility status.
* **Improvements**
  * Streamlined loading and error handling for better user experience.
  * Added helpful empty-state message with direct link to upload new materials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->