### PR TITLE
Feat: #7 [Backend] Persist a canonical material record after a confirmed mint

### DIFF
--- a/src/app/dashboard/upload/components/UploadWizard.jsx
+++ b/src/app/dashboard/upload/components/UploadWizard.jsx
@@ -207,6 +207,24 @@ export default function UploadWizard() {
           throw new Error("Invalid token ID in receipt");
         }
 
+        const materialData = {
+          userAddress: address,
+          tokenId,
+          txHash: receipt.transactionHash,
+          chainId: celoSepolia.id,
+          metadataUrl: uploadData.metadata,
+          fileUrl: uploadData.fileUrl,
+          thumbnailUrl: uploadData.imgUrl,
+          price,
+          visibility,
+        };
+
+        fetch("/api/persist-material", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ workflowId, materialData }),
+        });
+
         setMintResult({
           tokenId,
           txHash: receipt.transactionHash,

--- a/src/lib/backend/schemaContracts.js
+++ b/src/lib/backend/schemaContracts.js
@@ -16,6 +16,8 @@ export const REQUIRED_INDEXES = {
     { keys: { userAddress: 1, createdAt: -1 } },
     { keys: { visibility: 1, createdAt: -1 } },
     { keys: { materialId: 1 }, options: { sparse: true } },
+    { keys: { tokenId: 1 }, options: { unique: true, sparse: true } },
+    { keys: { txHash: 1 }, options: { unique: true, sparse: true } },
   ],
   purchases: [
     { keys: { buyerAddress: 1, createdAt: -1 } },

--- a/src/lib/backend/workflowOrchestrator.js
+++ b/src/lib/backend/workflowOrchestrator.js
@@ -225,3 +225,36 @@ export async function checkIdempotency(type, userAddress, idempotencyKey) {
     },
   });
 }
+
+/**
+ * Persist a canonical material record in MongoDB after a confirmed mint
+ * @param {string} workflowId - Workflow ID
+ * @param {Object} materialData - Material data
+ * @returns {Promise<Object>} Persisted material record
+ */
+export async function persistMaterialRecord(workflowId, materialData) {
+  const db = await getDb();
+  const collection = db.collection(COLLECTIONS.materials);
+
+  const materialRecord = applyTimestamps({
+    userAddress: materialData.userAddress,
+    tokenId: materialData.tokenId,
+    txHash: materialData.txHash,
+    chainId: materialData.chainId,
+    metadataUrl: materialData.metadataUrl,
+    fileUrl: materialData.fileUrl,
+    thumbnailUrl: materialData.thumbnailUrl,
+    price: materialData.price,
+    visibility: materialData.visibility,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  });
+
+  await collection.insertOne(materialRecord);
+  await confirmWorkflow(workflowId, {
+    txHash: materialData.txHash,
+    tokenId: materialData.tokenId,
+  });
+
+  return materialRecord;
+}


### PR DESCRIPTION
Closes #7

---


- Store  wallet address, token ID, tx hash, chain ID, metadata URL, file URL, thumbnail URL, price, visibility, and timestamps.
- Keep one canonical write path for published materials.
- Ensure the record shape serves both marketplace and dashboard use cases.
- Prevent abandoned or failed mint attempts from creating published records.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced the minting workflow to automatically persist and store complete transaction metadata when NFTs are confirmed. All mint details—including transaction hash, token identifiers, upload information, visibility settings, and pricing—are now securely saved in the system for future reference and audit purposes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->