### PR TITLE
feat: [contracts] Add Support for Multi-Asset Payments

### DIFF
--- a/soroban/contracts/material-registry/src/lib.rs
+++ b/soroban/contracts/material-registry/src/lib.rs
@@ -19,6 +19,28 @@ pub enum MaterialStatus {
     Archived = 2,
 }
 
+/// Classification of a Stellar asset supported by the registry.
+///
+/// - `Native`      – XLM (the Stellar native asset, wrapped via its SAC).
+/// - `Token`       – Any SAC-wrapped token such as USDC or EURC.
+/// - `CreatorToken`– A creator-specific SAC token (e.g. a course-access token
+///                   minted by the content creator themselves).
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum AssetKind {
+    Native = 0,
+    Token = 1,
+    CreatorToken = 2,
+}
+
+/// Metadata stored in the registry allowlist for each approved asset.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AllowedAssetInfo {
+    pub kind: AssetKind,
+    pub enabled: bool,
+}
+
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct AssetQuote {
@@ -54,6 +76,7 @@ enum DataKey {
     UpgradeAdmin,
     CreatorNonce(Address),
     Material(BytesN<32>),
+    AllowedAsset(Address),
 }
 
 #[contracterror]
@@ -74,6 +97,8 @@ pub enum RegistryError {
     MaterialAlreadyExists = 12,
     MaterialNotFound = 13,
     NotAuthorized = 14,
+    /// A quote asset is not in the registry's approved-asset allowlist.
+    UnapprovedAsset = 15,
 }
 
 #[contractevent(topics = ["material", "registered"], data_format = "vec")]
@@ -113,6 +138,16 @@ pub struct MaterialStatusUpdatedEvent {
     pub status: MaterialStatus,
 }
 
+/// Emitted when the upgrade-admin updates the approved-asset allowlist.
+#[contractevent(topics = ["asset", "policy_updated"], data_format = "vec")]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AssetPolicyUpdatedEvent {
+    #[topic]
+    pub asset: Address,
+    pub kind: AssetKind,
+    pub enabled: bool,
+}
+
 #[contract]
 pub struct MaterialRegistry;
 
@@ -131,6 +166,10 @@ impl MaterialRegistry {
         validate_metadata_uri(&metadata_uri)?;
         validate_quotes(&quotes)?;
         validate_payout_shares(&payout_shares)?;
+        // Asset allowlist is enforced once the upgrade-admin has been established
+        // (i.e. after the very first material registration). This allows the
+        // initial deployer to bootstrap assets without a chicken-and-egg problem.
+        validate_quote_assets(&env, &quotes)?;
         initialize_upgrade_admin_if_missing(&env, &creator);
 
         let next_nonce = get_creator_nonce(&env, &creator);
@@ -178,6 +217,7 @@ impl MaterialRegistry {
     ) -> Result<(), RegistryError> {
         validate_quotes(&quotes)?;
         validate_payout_shares(&payout_shares)?;
+        validate_quote_assets(&env, &quotes)?;
 
         let mut record = get_material_record(&env, &material_id)?;
         record.creator.require_auth();
@@ -246,6 +286,48 @@ impl MaterialRegistry {
 
         Ok(None)
     }
+
+    // ============== Asset Allowlist (SAC / Multi-Asset Support) ==============
+
+    /// Add or update an asset in the registry's approved-asset allowlist.
+    ///
+    /// Only the upgrade-admin may call this. Assets must be approved before
+    /// creators can include them in material quotes. Supports XLM (Native),
+    /// USDC/other SAC-wrapped tokens (Token), and creator-specific tokens
+    /// (CreatorToken).
+    pub fn set_asset_allowed(
+        env: Env,
+        admin: Address,
+        asset: Address,
+        kind: AssetKind,
+        enabled: bool,
+    ) -> Result<(), RegistryError> {
+        admin.require_auth();
+        require_upgrade_admin(&env, &admin)?;
+
+        let info = AllowedAssetInfo { kind, enabled };
+        env.storage()
+            .persistent()
+            .set(&DataKey::AllowedAsset(asset.clone()), &info);
+
+        AssetPolicyUpdatedEvent { asset, kind, enabled }.publish(&env);
+
+        Ok(())
+    }
+
+    /// Returns `true` when `asset` is in the allowlist and currently enabled.
+    pub fn is_asset_allowed(env: Env, asset: Address) -> bool {
+        get_allowed_asset_info(&env, &asset)
+            .map(|i| i.enabled)
+            .unwrap_or(false)
+    }
+
+    /// Returns the full `AllowedAssetInfo` record for `asset`, if present.
+    pub fn get_asset_info(env: Env, asset: Address) -> Option<AllowedAssetInfo> {
+        get_allowed_asset_info(&env, &asset)
+    }
+
+    // ============== Upgrade / Admin ==============
 
     /// Transfer upgrade admin role to another address.
     pub fn set_upgrade_admin(
@@ -410,6 +492,40 @@ fn require_upgrade_admin(env: &Env, candidate: &Address) -> Result<(), RegistryE
         .ok_or(RegistryError::NotAuthorized)?;
     if admin != *candidate {
         return Err(RegistryError::NotAuthorized);
+    }
+    Ok(())
+}
+
+// ============== Asset Allowlist Internals ==============
+
+fn get_allowed_asset_info(env: &Env, asset: &Address) -> Option<AllowedAssetInfo> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::AllowedAsset(asset.clone()))
+}
+
+/// Validate that every asset referenced in `quotes` is present in the
+/// allowlist and currently enabled.
+///
+/// Validation is skipped when the upgrade-admin has not yet been set (i.e.
+/// before the very first `register_material` call) to avoid a bootstrap
+/// deadlock where no admin exists to pre-approve assets.
+fn validate_quote_assets(env: &Env, quotes: &Vec<AssetQuote>) -> Result<(), RegistryError> {
+    // No allowlist enforcement until an upgrade-admin is established.
+    if !env.storage().persistent().has(&DataKey::UpgradeAdmin) {
+        return Ok(());
+    }
+
+    let mut index = 0;
+    while index < quotes.len() {
+        let quote = quotes.get_unchecked(index);
+        let approved = get_allowed_asset_info(env, &quote.asset)
+            .map(|i| i.enabled)
+            .unwrap_or(false);
+        if !approved {
+            return Err(RegistryError::UnapprovedAsset);
+        }
+        index += 1;
     }
     Ok(())
 }

--- a/soroban/contracts/material-registry/src/test.rs
+++ b/soroban/contracts/material-registry/src/test.rs
@@ -269,6 +269,10 @@ fn updates_sale_terms_and_status_and_supports_quote_lookup() {
     let tracked_asset = next_quotes.get_unchecked(0).asset.clone();
     let next_payout_shares = replacement_payout_shares(&env);
 
+    // Approve the replacement asset before updating sale terms.
+    // The upgrade-admin is the first creator; auth is mocked for the whole test.
+    client.set_asset_allowed(&creator, &tracked_asset, &AssetKind::Token, &true);
+
     client.update_sale_terms(&material_id, &next_quotes, &next_payout_shares);
     client.set_material_status(&material_id, &MaterialStatus::Paused);
 
@@ -281,11 +285,12 @@ fn updates_sale_terms_and_status_and_supports_quote_lookup() {
     assert_eq!(record.payout_shares, next_payout_shares);
     assert_eq!(quote, Some(next_quotes.get_unchecked(0)));
     assert_eq!(missing_quote, None);
-    assert_eq!(env.events().all().len(), 3);
+    // Events: registered + asset_policy_updated + sale_terms_updated + status_updated
+    assert_eq!(env.events().all().len(), 4);
 
     let events = env.events().all();
     assert_eq!(
-        events.get_unchecked(1),
+        events.get_unchecked(2),
         (
             contract_id.clone(),
             (
@@ -305,7 +310,7 @@ fn updates_sale_terms_and_status_and_supports_quote_lookup() {
         )
     );
     assert_eq!(
-        events.get_unchecked(2),
+        events.get_unchecked(3),
         (
             contract_id,
             (
@@ -345,4 +350,164 @@ fn bootstraps_and_transfers_upgrade_admin() {
 
     let denied = client.try_set_upgrade_admin(&creator, &Address::generate(&env));
     assert_eq!(denied, Err(Ok(RegistryError::NotAuthorized)));
+}
+
+// ============== Asset Allowlist Tests ==============
+
+#[test]
+fn set_asset_allowed_stores_info_and_emits_event() {
+    let env = Env::default();
+    let (contract_id, client) = install_contract(&env);
+    env.mock_all_auths();
+
+    let creator = Address::generate(&env);
+    let xlm = Address::generate(&env);
+
+    // Bootstrap: first registration sets upgrade-admin = creator
+    client.register_material(
+        &creator,
+        &metadata_uri(&env),
+        &bytes32(&env, 1),
+        &bytes32(&env, 2),
+        &default_quotes(&env),
+        &default_payout_shares(&env),
+    );
+
+    assert!(!client.is_asset_allowed(&xlm));
+    assert!(client.get_asset_info(&xlm).is_none());
+
+    client.set_asset_allowed(&creator, &xlm, &AssetKind::Native, &true);
+
+    assert!(client.is_asset_allowed(&xlm));
+    let info = client.get_asset_info(&xlm).unwrap();
+    assert_eq!(info.kind, AssetKind::Native);
+    assert!(info.enabled);
+
+    // Check event
+    let events = env.events().all();
+    let last = events.get_unchecked(events.len() - 1);
+    assert_eq!(
+        last,
+        (
+            contract_id,
+            (Symbol::new(&env, "asset"), Symbol::new(&env, "policy_updated"), xlm.clone())
+                .into_val(&env),
+            vec![&env, AssetKind::Native.into_val(&env), true.into_val(&env)].into_val(&env),
+        )
+    );
+}
+
+#[test]
+fn disabling_asset_blocks_quote_registration() {
+    let env = Env::default();
+    let (_contract_id, client) = install_contract(&env);
+    env.mock_all_auths();
+
+    let creator = Address::generate(&env);
+    let usdc = Address::generate(&env);
+
+    // First registration; no admin yet so validation is skipped.
+    client.register_material(
+        &creator,
+        &metadata_uri(&env),
+        &bytes32(&env, 1),
+        &bytes32(&env, 2),
+        &default_quotes(&env),
+        &default_payout_shares(&env),
+    );
+
+    // Allow USDC, then immediately disable it.
+    client.set_asset_allowed(&creator, &usdc, &AssetKind::Token, &true);
+    client.set_asset_allowed(&creator, &usdc, &AssetKind::Token, &false);
+
+    // Attempting to register a second material quoting the disabled asset must fail.
+    let bad_quotes = vec![
+        &env,
+        AssetQuote { asset: usdc, amount: 1_000_000 },
+    ];
+    let result = client.try_register_material(
+        &creator,
+        &metadata_uri(&env),
+        &bytes32(&env, 10),
+        &bytes32(&env, 11),
+        &bad_quotes,
+        &default_payout_shares(&env),
+    );
+    assert_eq!(result, Err(Ok(RegistryError::UnapprovedAsset)));
+}
+
+#[test]
+fn update_sale_terms_rejects_unapproved_asset() {
+    let env = Env::default();
+    let (_contract_id, client) = install_contract(&env);
+    env.mock_all_auths();
+
+    let creator = Address::generate(&env);
+
+    // First registration; no admin yet so validation skipped.
+    let material_id = client.register_material(
+        &creator,
+        &metadata_uri(&env),
+        &bytes32(&env, 1),
+        &bytes32(&env, 2),
+        &default_quotes(&env),
+        &default_payout_shares(&env),
+    );
+
+    // Try to update with an asset that has never been approved.
+    let unapproved = Address::generate(&env);
+    let bad_quotes = vec![&env, AssetQuote { asset: unapproved, amount: 5_000_000 }];
+
+    let result = client.try_update_sale_terms(
+        &material_id,
+        &bad_quotes,
+        &default_payout_shares(&env),
+    );
+    assert_eq!(result, Err(Ok(RegistryError::UnapprovedAsset)));
+}
+
+#[test]
+fn non_admin_cannot_set_asset_allowed() {
+    let env = Env::default();
+    let (_contract_id, client) = install_contract(&env);
+    env.mock_all_auths();
+
+    let creator = Address::generate(&env);
+    let intruder = Address::generate(&env);
+    let asset = Address::generate(&env);
+
+    // Bootstrap admin.
+    client.register_material(
+        &creator,
+        &metadata_uri(&env),
+        &bytes32(&env, 1),
+        &bytes32(&env, 2),
+        &default_quotes(&env),
+        &default_payout_shares(&env),
+    );
+
+    let result = client.try_set_asset_allowed(&intruder, &asset, &AssetKind::Token, &true);
+    assert_eq!(result, Err(Ok(RegistryError::NotAuthorized)));
+}
+
+#[test]
+fn first_registration_skips_asset_validation() {
+    // Before any material has been registered the upgrade-admin key does not
+    // exist, so asset allowlist validation must be bypassed entirely.
+    let env = Env::default();
+    let (_contract_id, client) = install_contract(&env);
+    env.mock_all_auths();
+
+    let creator = Address::generate(&env);
+    // Use completely random, never-approved addresses for the quotes.
+    let result = client.try_register_material(
+        &creator,
+        &metadata_uri(&env),
+        &bytes32(&env, 1),
+        &bytes32(&env, 2),
+        &default_quotes(&env),
+        &default_payout_shares(&env),
+    );
+    // Should succeed even though no assets are pre-approved.
+    assert!(result.is_ok());
 }

--- a/soroban/contracts/purchase-manager/src/lib.rs
+++ b/soroban/contracts/purchase-manager/src/lib.rs
@@ -17,6 +17,29 @@ pub enum MaterialStatus {
     Archived = 2,
 }
 
+/// Classification of a Stellar asset accepted by the purchase manager.
+///
+/// Must be kept in sync with `AssetKind` in the material-registry contract.
+///
+/// - `Native`      – XLM (Stellar native asset via its SAC).
+/// - `Token`       – SAC-wrapped token (e.g. USDC, EURC).
+/// - `CreatorToken`– Creator-specific SAC token.
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum AssetKind {
+    Native = 0,
+    Token = 1,
+    CreatorToken = 2,
+}
+
+/// Allowlist record stored for each approved payment asset.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AssetInfo {
+    pub kind: AssetKind,
+    pub enabled: bool,
+}
+
 /// Asset quote structure from registry
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -52,6 +75,10 @@ pub struct PlatformConfig {
     pub treasury: Address,
     pub platform_fee_bps: u32,
     pub paused: bool,
+    /// Optional price-oracle address for future cross-asset conversion support.
+    /// When `None`, no oracle is configured and all prices must be quoted in
+    /// the exact accepted asset (no conversion).
+    pub oracle: Option<Address>,
 }
 
 /// Entitlement record for a successful purchase
@@ -148,6 +175,7 @@ pub struct PayoutDistributedEvent {
 pub struct AssetPolicyUpdatedEvent {
     #[topic]
     pub asset: Address,
+    pub kind: AssetKind,
     pub enabled: bool,
 }
 
@@ -164,14 +192,86 @@ pub struct PlatformConfigUpdatedEvent {
 #[contract]
 pub struct PurchaseManager;
 
+// ============== SAC Token Interface (SEP-41) ==============
+
+/// Wrapper around a Stellar Asset Contract (SAC) address that exposes the
+/// SEP-41 token interface methods needed by the purchase flow.
+///
+/// Both XLM (via its native SAC) and any other SAC-wrapped token (USDC, EURC,
+/// creator tokens, …) implement this interface, so the purchase logic is
+/// asset-agnostic.
+pub struct SacToken<'a> {
+    env: &'a Env,
+    address: &'a Address,
+}
+
+impl<'a> SacToken<'a> {
+    pub fn new(env: &'a Env, address: &'a Address) -> Self {
+        SacToken { env, address }
+    }
+
+    /// Transfer `amount` tokens from `from` to `to`.
+    /// Equivalent to calling `transfer(from, to, amount)` on the SAC.
+    pub fn transfer(&self, from: &Address, to: &Address, amount: i128) {
+        let func = Symbol::new(self.env, "transfer");
+        let args = Vec::from_array(
+            self.env,
+            [
+                from.into_val(self.env),
+                to.into_val(self.env),
+                amount.into_val(self.env),
+            ],
+        );
+        self.env.invoke_contract::<()>(self.address, &func, args);
+    }
+
+    /// Query the token balance of `id`.
+    /// Equivalent to calling `balance(id)` on the SAC.
+    pub fn balance(&self, id: &Address) -> i128 {
+        let func = Symbol::new(self.env, "balance");
+        let args = Vec::from_array(self.env, [id.into_val(self.env)]);
+        self.env.invoke_contract::<i128>(self.address, &func, args)
+    }
+}
+
+// ============== Price Oracle Stub ==============
+
+/// Stub for a future price-oracle integration (e.g. Reflector Oracle / SEP-40).
+///
+/// Returns `None` for every query until a concrete oracle is integrated.
+/// The `oracle` field in `PlatformConfig` holds the oracle contract address
+/// once deployed.
+pub struct PriceOracle<'a> {
+    env: &'a Env,
+    address: &'a Address,
+}
+
+impl<'a> PriceOracle<'a> {
+    pub fn new(env: &'a Env, address: &'a Address) -> Self {
+        PriceOracle { env, address }
+    }
+
+    /// Returns the last price of `base` denominated in `quote` as
+    /// `Some((price, decimals))`, or `None` when the oracle is unavailable.
+    ///
+    /// TODO: implement Reflector Oracle or equivalent SEP-40 feed when an
+    ///       on-chain price source is available on the target network.
+    pub fn last_price(&self, _base: &Address, _quote: &Address) -> Option<(i128, u32)> {
+        let _ = (self.env, self.address);
+        None
+    }
+}
+
+// ============== Registry Cross-Contract Interface ==============
+
 /// Interface for calling MaterialRegistry contract
 pub trait MaterialRegistryInterface {
-    fn get_material(env: &Env, material_id: &BytesN<32>) -> Result<MaterialRecord, PurchaseError>;
+    fn get_material(&self, env: &Env, material_id: &BytesN<32>) -> Result<MaterialRecord, PurchaseError>;
 }
 
 /// Interface implementation using cross-contract call
 impl MaterialRegistryInterface for Address {
-    fn get_material(env: &Env, material_id: &BytesN<32>) -> Result<MaterialRecord, PurchaseError> {
+    fn get_material(&self, env: &Env, material_id: &BytesN<32>) -> Result<MaterialRecord, PurchaseError> {
         let func = Symbol::new(env, "get_material");
         let result: Result<MaterialRecord, PurchaseError> = env
             .invoke_contract(self, &func, Vec::from_array(env, [material_id.into_val(env)]));
@@ -212,6 +312,7 @@ impl PurchaseManager {
             treasury,
             platform_fee_bps,
             paused: false,
+            oracle: None,
         };
 
         env.storage()
@@ -385,22 +486,29 @@ impl PurchaseManager {
 
     // ============== Admin Functions ==============
 
-    /// Set whether an asset is allowed for purchases (admin only)
+    /// Set whether an asset is allowed for purchases (admin only).
+    ///
+    /// `kind` classifies the asset: `Native` for XLM, `Token` for SAC-wrapped
+    /// fungible tokens such as USDC, and `CreatorToken` for creator-specific
+    /// tokens. The classification is stored for informational purposes and
+    /// future filtering.
     pub fn set_asset_allowed(
         env: Env,
         admin: Address,
         asset: Address,
+        kind: AssetKind,
         enabled: bool,
     ) -> Result<(), PurchaseError> {
         admin.require_auth();
         verify_admin(&env, &admin)?;
 
+        let info = AssetInfo { kind, enabled };
         env.storage()
             .persistent()
-            .set(&DataKey::AllowedAsset(asset.clone()), &enabled);
+            .set(&DataKey::AllowedAsset(asset.clone()), &info);
 
         // Emit policy update event
-        AssetPolicyUpdatedEvent { asset, enabled }.publish(&env);
+        AssetPolicyUpdatedEvent { asset, kind, enabled }.publish(&env);
 
         Ok(())
     }
@@ -433,6 +541,8 @@ impl PurchaseManager {
             treasury,
             platform_fee_bps,
             paused,
+            // Preserve the existing oracle; use set_oracle() to change it.
+            oracle: current_config.oracle,
         };
 
         env.storage()
@@ -446,6 +556,32 @@ impl PurchaseManager {
             paused,
         }
         .publish(&env);
+
+        Ok(())
+    }
+
+    /// Returns the full `AssetInfo` record for `asset`, if present.
+    pub fn get_asset_info(env: Env, asset: Address) -> Option<AssetInfo> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::AllowedAsset(asset))
+    }
+
+    /// Configure the price-oracle address used for future cross-asset
+    /// conversion (admin only). Pass `None` to clear the oracle.
+    pub fn set_oracle(
+        env: Env,
+        admin: Address,
+        oracle: Option<Address>,
+    ) -> Result<(), PurchaseError> {
+        admin.require_auth();
+        verify_admin(&env, &admin)?;
+
+        let mut config = get_platform_config(&env)?;
+        config.oracle = oracle;
+        env.storage()
+            .persistent()
+            .set(&DataKey::PlatformConfig, &config);
 
         Ok(())
     }
@@ -507,7 +643,8 @@ fn verify_admin(env: &Env, admin: &Address) -> Result<(), PurchaseError> {
 fn is_asset_allowed(env: &Env, asset: &Address) -> bool {
     env.storage()
         .persistent()
-        .get(&DataKey::AllowedAsset(asset.clone()))
+        .get::<DataKey, AssetInfo>(&DataKey::AllowedAsset(asset.clone()))
+        .map(|info| info.enabled)
         .unwrap_or(false)
 }
 
@@ -542,18 +679,9 @@ fn transfer_asset(
     asset: &Address,
     amount: i128,
 ) -> Result<(), PurchaseError> {
-    // Use Stellar Asset Contract transfer
-    let func = Symbol::new(env, "transfer");
-    let args = Vec::from_array(
-        env,
-        [
-            from.into_val(env),
-            to.into_val(env),
-            amount.into_val(env),
-        ],
-    );
-    
-    env.invoke_contract::<()>(asset, &func, args);
+    // Delegate to the Stellar Asset Contract (SAC) via the SEP-41 interface.
+    // Works for XLM (native SAC), USDC, and any other SAC-wrapped token.
+    SacToken::new(env, asset).transfer(from, to, amount);
     Ok(())
 }
 

--- a/soroban/contracts/purchase-manager/src/test.rs
+++ b/soroban/contracts/purchase-manager/src/test.rs
@@ -169,9 +169,14 @@ fn sets_asset_allowed() {
 
     assert!(!client.is_asset_allowed(&asset));
 
-    client.set_asset_allowed(&admin, &asset, &true);
+    client.set_asset_allowed(&admin, &asset, &AssetKind::Token, &true);
 
     assert!(client.is_asset_allowed(&asset));
+
+    // Verify get_asset_info returns the stored AssetInfo
+    let info = client.get_asset_info(&asset).unwrap();
+    assert_eq!(info.kind, AssetKind::Token);
+    assert!(info.enabled);
 
     // Check event
     let events = env.events().all();
@@ -186,7 +191,7 @@ fn sets_asset_allowed() {
                 asset.clone(),
             )
                 .into_val(&env),
-            vec![&env, true.into_val(&env)].into_val(&env),
+            vec![&env, AssetKind::Token.into_val(&env), true.into_val(&env)].into_val(&env),
         )
     );
 }
@@ -279,7 +284,7 @@ fn rejects_admin_calls_from_non_admin() {
 
     let (_, client) = install_and_init_contract(&env, &admin, &registry, &treasury, 500);
 
-    let result = client.try_set_asset_allowed(&non_admin, &asset, &true);
+    let result = client.try_set_asset_allowed(&non_admin, &asset, &AssetKind::Token, &true);
     assert_eq!(result, Err(Ok(PurchaseError::NotAuthorized)));
 }
 
@@ -315,8 +320,8 @@ fn successful_purchase_creates_entitlement() {
     // Setup contract
     let (_contract_id, client) = install_and_init_contract(&env, &admin, &registry, &treasury, 500);
 
-    // Enable asset
-    client.set_asset_allowed(&admin, &asset, &true);
+    // Enable asset (USDC-style token)
+    client.set_asset_allowed(&admin, &asset, &AssetKind::Token, &true);
 
     let purchase_id = client.purchase(&buyer, &material_id, &asset, &1_000_000);
     assert_eq!(purchase_id, 0);
@@ -342,7 +347,7 @@ fn rejects_purchase_when_paused() {
     let (contract_id, client) = install_and_init_contract(&env, &admin, &registry, &treasury, 500);
 
     // Enable asset
-    client.set_asset_allowed(&admin, &asset, &true);
+    client.set_asset_allowed(&admin, &asset, &AssetKind::Token, &true);
 
     // Pause the contract
     client.set_platform_config(&admin, &treasury, &500, &true);
@@ -525,11 +530,13 @@ fn asset_can_be_disabled() {
 
     let (_, client) = install_and_init_contract(&env, &admin, &registry, &treasury, 500);
 
-    // Enable then disable
-    client.set_asset_allowed(&admin, &asset, &true);
+    // Enable (as Native/XLM) then disable
+    client.set_asset_allowed(&admin, &asset, &AssetKind::Native, &true);
     assert!(client.is_asset_allowed(&asset));
+    let info = client.get_asset_info(&asset).unwrap();
+    assert_eq!(info.kind, AssetKind::Native);
 
-    client.set_asset_allowed(&admin, &asset, &false);
+    client.set_asset_allowed(&admin, &asset, &AssetKind::Native, &false);
     assert!(!client.is_asset_allowed(&asset));
 }
 
@@ -720,4 +727,39 @@ fn payout_distributed_event_struct_works() {
     assert_eq!(event.purchase_id, 1);
     assert_eq!(event.recipient, recipient);
     assert_eq!(event.amount, 950_000);
+}
+
+#[test]
+fn set_oracle_and_get_asset_info_work() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let registry = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let asset = Address::generate(&env);
+    let oracle = Address::generate(&env);
+
+    let (_, client) = install_and_init_contract(&env, &admin, &registry, &treasury, 500);
+
+    // Oracle should be None by default
+    let config = client.get_platform_config().unwrap();
+    assert!(config.oracle.is_none());
+
+    // Set oracle
+    client.set_oracle(&admin, &Some(oracle.clone()));
+    let config = client.get_platform_config().unwrap();
+    assert_eq!(config.oracle, Some(oracle.clone()));
+
+    // Clear oracle
+    client.set_oracle(&admin, &None);
+    let config = client.get_platform_config().unwrap();
+    assert!(config.oracle.is_none());
+
+    // Asset info
+    assert!(client.get_asset_info(&asset).is_none());
+    client.set_asset_allowed(&admin, &asset, &AssetKind::Token, &true);
+    let info = client.get_asset_info(&asset).unwrap();
+    assert_eq!(info.kind, AssetKind::Token);
+    assert!(info.enabled);
 }


### PR DESCRIPTION
Closes #67 

Description

Expand the registration and purchase contracts to support a wider range of Stellar assets (XLM, USDC, and potentially creator-specific tokens).
Key Requirements

    Asset Validation: Ensure only approved assets can be used for pricing.
    SAC Integration: Use the Stellar Asset Contract (SAC) interface for interoperability.
    Price Feeds (Optional): Explore using oracles if price conversion is needed in the future.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced asset approval system enabling administrators to manage which assets can be used in material creation and sales operations.
  * Material registration and sales term updates now validate assets against an approved allowlist, rejecting unapproved assets.
  * Added asset classification by type (Native, Standard Token, Creator Token).
  * Enabled optional oracle configuration for platform settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->