### PR TITLE
Fix transaction history API and material pause controls

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -309,6 +309,51 @@ paths:
         "401":
           $ref: "#/components/responses/Unauthorized"
 
+  /api/transactions/history:
+    get:
+      summary: Aggregate account purchase and Stellar transaction history
+      operationId: listTransactionHistory
+      tags: [Purchase]
+      parameters:
+        - name: page
+          in: query
+          schema:
+            type: integer
+            default: 1
+            minimum: 1
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            default: 20
+            minimum: 1
+            maximum: 100
+      responses:
+        "200":
+          description: Paginated merged history from MongoDB and Horizon
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  page:
+                    type: integer
+                  limit:
+                    type: integer
+                  hasMore:
+                    type: boolean
+                  totals:
+                    type: object
+                    properties:
+                      purchases:
+                        type: integer
+                  records:
+                    type: array
+                    items:
+                      type: object
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
   # ---------------------------------------------------------------------------
   # Entitlements
   # ---------------------------------------------------------------------------

--- a/public/openapi.yaml
+++ b/public/openapi.yaml
@@ -309,6 +309,51 @@ paths:
         "401":
           $ref: "#/components/responses/Unauthorized"
 
+  /api/transactions/history:
+    get:
+      summary: Aggregate account purchase and Stellar transaction history
+      operationId: listTransactionHistory
+      tags: [Purchase]
+      parameters:
+        - name: page
+          in: query
+          schema:
+            type: integer
+            default: 1
+            minimum: 1
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            default: 20
+            minimum: 1
+            maximum: 100
+      responses:
+        "200":
+          description: Paginated merged history from MongoDB and Horizon
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  page:
+                    type: integer
+                  limit:
+                    type: integer
+                  hasMore:
+                    type: boolean
+                  totals:
+                    type: object
+                    properties:
+                      purchases:
+                        type: integer
+                  records:
+                    type: array
+                    items:
+                      type: object
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
   # ---------------------------------------------------------------------------
   # Entitlements
   # ---------------------------------------------------------------------------

--- a/soroban/contracts/material-registry/src/lib.rs
+++ b/soroban/contracts/material-registry/src/lib.rs
@@ -254,17 +254,19 @@ impl MaterialRegistry {
 
     pub fn set_material_status(
         env: Env,
+        actor: Address,
         material_id: BytesN<32>,
         status: MaterialStatus,
     ) -> Result<(), RegistryError> {
         let mut record = get_material_record(&env, &material_id)?;
-        record.creator.require_auth();
+        require_creator_or_upgrade_admin(&env, &record.creator, &actor)?;
 
         if record.status == status {
             return Ok(());
         }
 
         record.status = status;
+        record.paused = status == MaterialStatus::Paused;
         record.updated_ledger = env.ledger().sequence();
         put_material(&env, &record);
 
@@ -275,6 +277,85 @@ impl MaterialRegistry {
         }
         .publish(&env);
 
+        MaterialStatusChangedEvent {
+            material_id: material_id.clone(),
+            creator: record.creator.clone(),
+            paused: record.paused,
+            status,
+        }
+        .publish(&env);
+
+        Ok(())
+    }
+
+    pub fn set_material_paused(
+        env: Env,
+        actor: Address,
+        material_id: BytesN<32>,
+        paused: bool,
+    ) -> Result<(), RegistryError> {
+        let status = if paused {
+            MaterialStatus::Paused
+        } else {
+            MaterialStatus::Active
+        };
+        Self::set_material_status(env, actor, material_id, status)
+    }
+
+    pub fn toggle_material_paused(
+        env: Env,
+        actor: Address,
+        material_id: BytesN<32>,
+    ) -> Result<(), RegistryError> {
+        let record = get_material_record(&env, &material_id)?;
+        Self::set_material_paused(env, actor, material_id, !record.paused)
+    }
+
+    pub fn is_material_paused(
+        env: Env,
+        material_id: BytesN<32>,
+    ) -> Result<bool, RegistryError> {
+        let record = get_material_record(&env, &material_id)?;
+        Ok(record.paused)
+    }
+
+    pub fn set_material_active(
+        env: Env,
+        actor: Address,
+        material_id: BytesN<32>,
+        active: bool,
+    ) -> Result<(), RegistryError> {
+        Self::set_material_paused(env, actor, material_id, !active)
+    }
+
+    pub fn set_material_deactivated(
+        env: Env,
+        actor: Address,
+        material_id: BytesN<32>,
+        deactivated: bool,
+    ) -> Result<(), RegistryError> {
+        let mut record = get_material_record(&env, &material_id)?;
+        require_creator_or_upgrade_admin(&env, &record.creator, &actor)?;
+        let next_status = if deactivated {
+            MaterialStatus::Archived
+        } else if record.paused {
+            MaterialStatus::Paused
+        } else {
+            MaterialStatus::Active
+        };
+        if record.status == next_status {
+            return Ok(());
+        }
+        record.status = next_status;
+        record.updated_ledger = env.ledger().sequence();
+        put_material(&env, &record);
+        MaterialStatusChangedEvent {
+            material_id: material_id.clone(),
+            creator: record.creator.clone(),
+            paused: record.paused,
+            status: next_status,
+        }
+        .publish(&env);
         Ok(())
     }
 
@@ -515,6 +596,18 @@ fn require_upgrade_admin(env: &Env, candidate: &Address) -> Result<(), RegistryE
         return Err(RegistryError::NotAuthorized);
     }
     Ok(())
+}
+
+fn require_creator_or_upgrade_admin(
+    env: &Env,
+    creator: &Address,
+    actor: &Address,
+) -> Result<(), RegistryError> {
+    actor.require_auth();
+    if actor == creator {
+        return Ok(());
+    }
+    require_upgrade_admin(env, actor)
 }
 
 // ============== Asset Allowlist Internals ==============

--- a/soroban/contracts/material-registry/src/lib.rs
+++ b/soroban/contracts/material-registry/src/lib.rs
@@ -63,6 +63,7 @@ pub struct MaterialRecord {
     pub metadata_uri: String,
     pub metadata_hash: BytesN<32>,
     pub rights_hash: BytesN<32>,
+    pub paused: bool,
     pub status: MaterialStatus,
     pub quotes: Vec<AssetQuote>,
     pub payout_shares: Vec<PayoutShare>,
@@ -138,6 +139,17 @@ pub struct MaterialStatusUpdatedEvent {
     pub status: MaterialStatus,
 }
 
+#[contractevent(topics = ["material", "status_changed"], data_format = "vec")]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MaterialStatusChangedEvent {
+    #[topic]
+    pub material_id: BytesN<32>,
+    #[topic]
+    pub creator: Address,
+    pub paused: bool,
+    pub status: MaterialStatus,
+}
+
 /// Emitted when the upgrade-admin updates the approved-asset allowlist.
 #[contractevent(topics = ["asset", "policy_updated"], data_format = "vec")]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -185,6 +197,7 @@ impl MaterialRegistry {
             metadata_uri: metadata_uri.clone(),
             metadata_hash: metadata_hash.clone(),
             rights_hash: rights_hash.clone(),
+            paused: false,
             status: MaterialStatus::Active,
             quotes: quotes.clone(),
             payout_shares: payout_shares.clone(),

--- a/soroban/contracts/material-registry/src/test.rs
+++ b/soroban/contracts/material-registry/src/test.rs
@@ -86,6 +86,7 @@ fn seed_material(
         metadata_uri: metadata_uri(env),
         metadata_hash: bytes32(env, 1),
         rights_hash: bytes32(env, 2),
+        paused: false,
         status: MaterialStatus::Active,
         quotes: default_quotes(env),
         payout_shares: default_payout_shares(env),
@@ -125,6 +126,7 @@ fn registers_material_and_emits_registered_event() {
     assert_eq!(record.metadata_uri, metadata_uri);
     assert_eq!(record.metadata_hash, metadata_hash);
     assert_eq!(record.rights_hash, rights_hash);
+    assert!(!record.paused);
     assert_eq!(record.status, MaterialStatus::Active);
     assert_eq!(record.quotes, quotes);
     assert_eq!(record.payout_shares, payout_shares);
@@ -462,9 +464,9 @@ fn updates_sale_terms_and_status_and_supports_quote_lookup() {
         .to_xdr(&env, &contract_id)
     );
 
-    client.set_material_status(&material_id, &MaterialStatus::Paused);
+    client.set_material_status(&creator, &material_id, &MaterialStatus::Paused);
     let status_events = env.events().all();
-    assert_eq!(status_events.events().len(), 1);
+    assert_eq!(status_events.events().len(), 2);
     assert_eq!(
         &status_events.events()[0],
         &MaterialStatusUpdatedEvent {
@@ -480,6 +482,7 @@ fn updates_sale_terms_and_status_and_supports_quote_lookup() {
     let missing_quote = client.get_quote(&material_id, &Address::generate(&env));
 
     assert_eq!(record.status, MaterialStatus::Paused);
+    assert!(record.paused);
     assert_eq!(record.quotes, next_quotes);
     assert_eq!(record.payout_shares, next_payout_shares);
     assert_eq!(quote, Some(next_quotes.get_unchecked(0)));

--- a/soroban/contracts/purchase-manager/src/lib.rs
+++ b/soroban/contracts/purchase-manager/src/lib.rs
@@ -63,6 +63,7 @@ pub struct PayoutShare {
 pub struct MaterialRecord {
     pub material_id: BytesN<32>,
     pub creator: Address,
+    pub paused: bool,
     pub status: MaterialStatus,
     pub quotes: Vec<AssetQuote>,
     pub payout_shares: Vec<PayoutShare>,
@@ -384,7 +385,7 @@ impl PurchaseManager {
             .map_err(|_| PurchaseError::MaterialNotFound)?;
 
         // Verify material is active
-        if material.status != MaterialStatus::Active {
+        if material.status != MaterialStatus::Active || material.paused {
             return Err(PurchaseError::MaterialNotActive);
         }
 

--- a/soroban/contracts/purchase-manager/src/test.rs
+++ b/soroban/contracts/purchase-manager/src/test.rs
@@ -332,6 +332,7 @@ fn successful_purchase_creates_entitlement_and_distributes_multiple_payouts() {
     let material = MaterialRecord {
         material_id: material_id.clone(),
         creator: creator.clone(),
+        paused: false,
         status: MaterialStatus::Active,
         quotes: vec![
             &env,
@@ -412,6 +413,7 @@ fn purchase_distribution_gives_final_recipient_rounding_remainder() {
     let material = MaterialRecord {
         material_id: material_id.clone(),
         creator,
+        paused: false,
         status: MaterialStatus::Active,
         quotes: vec![
             &env,
@@ -488,6 +490,7 @@ fn rejects_invalid_registry_payout_shares_before_asset_transfer() {
     let material = MaterialRecord {
         material_id: material_id.clone(),
         creator,
+        paused: false,
         status: MaterialStatus::Active,
         quotes: vec![
             &env,
@@ -564,6 +567,49 @@ fn rejects_purchase_when_asset_not_allowed() {
 
     let result = client.try_purchase(&buyer, &material_id, &asset, &1_000_000);
     assert_eq!(result, Err(Ok(PurchaseError::AssetNotAllowed)));
+}
+
+#[test]
+fn rejects_purchase_when_material_is_paused() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let registry = env.register(MockRegistry, ());
+    let treasury = Address::generate(&env);
+    let buyer = Address::generate(&env);
+    let creator = Address::generate(&env);
+    let asset = env.register(MockAsset, ());
+
+    let material_id = bytes32(&env, 21);
+    let material = MaterialRecord {
+        material_id: material_id.clone(),
+        creator,
+        paused: true,
+        status: MaterialStatus::Paused,
+        quotes: vec![
+            &env,
+            AssetQuote {
+                asset: asset.clone(),
+                amount: 1_000_000,
+            },
+        ],
+        payout_shares: vec![
+            &env,
+            PayoutShare {
+                recipient: Address::generate(&env),
+                share_bps: 10_000,
+            },
+        ],
+    };
+    let registry_client = MockRegistryClient::new(&env, &registry);
+    registry_client.set_material(&material_id, &material);
+
+    let (_, client) = install_and_init_contract(&env, &admin, &registry, &treasury, 500);
+    client.set_asset_allowed(&admin, &asset, &AssetKind::Token, &true);
+
+    let result = client.try_purchase(&buyer, &material_id, &asset, &1_000_000);
+    assert_eq!(result, Err(Ok(PurchaseError::MaterialNotActive)));
 }
 
 // ============== Entitlement Query Tests ==============
@@ -782,6 +828,7 @@ fn material_record_struct_works() {
     let record = MaterialRecord {
         material_id: material_id.clone(),
         creator: creator.clone(),
+        paused: false,
         status: MaterialStatus::Active,
         quotes: vec![
             &env,

--- a/src/app/api/transactions/history/route.js
+++ b/src/app/api/transactions/history/route.js
@@ -48,20 +48,27 @@ export async function GET(request) {
     const db = await getDb();
     const skip = (page - 1) * limit;
 
+    const buyerAddressLower = String(buyerAddress).toLowerCase();
+    const purchaseFilter = {
+      $or: [{ buyerAddress }, { buyerAddress: buyerAddressLower }],
+    };
+
     const [purchases, purchaseTotal, onchain] = await Promise.all([
       db
         .collection("purchases")
-        .find({ buyerAddress: String(buyerAddress).toLowerCase() })
+        .find(purchaseFilter)
         .sort({ purchasedAt: -1, createdAt: -1, updatedAt: -1 })
         .skip(skip)
         .limit(limit)
         .toArray(),
-      db.collection("purchases").countDocuments({ buyerAddress: String(buyerAddress).toLowerCase() }),
+      db.collection("purchases").countDocuments(purchaseFilter),
       fetchHorizonTransactions(String(buyerAddress), { page, limit }),
     ]);
 
     const purchaseRecords = buildPurchaseHistoryRecords(purchases);
-    const combined = [...purchaseRecords, ...onchain.records].sort((a, b) => {
+    const purchaseHashes = new Set(purchaseRecords.map((entry) => entry.hash).filter(Boolean));
+    const uniqueOnchain = onchain.records.filter((entry) => !entry.hash || !purchaseHashes.has(entry.hash));
+    const combined = [...purchaseRecords, ...uniqueOnchain].sort((a, b) => {
       const left = new Date(a.createdAt || 0).getTime();
       const right = new Date(b.createdAt || 0).getTime();
       return right - left;

--- a/src/app/api/transactions/history/route.js
+++ b/src/app/api/transactions/history/route.js
@@ -1,0 +1,83 @@
+export const dynamic = "force-dynamic";
+
+import { NextResponse } from "next/server";
+import { getDb } from "@/lib/mongodb";
+import { verifyDashboardToken } from "@/lib/auth/session";
+import {
+  buildPurchaseHistoryRecords,
+  fetchHorizonTransactions,
+} from "@/lib/transactions/historyFeed";
+
+async function getUserFromCookie(request) {
+  const cookieHeader = request.headers.get("cookie") || "";
+  const cookieMatch = cookieHeader.match(/auth_token=([^;]+)/);
+  const token = cookieMatch ? decodeURIComponent(cookieMatch[1]) : null;
+  if (!token) return null;
+  const verification = await verifyDashboardToken(token, process.env.JWT_SECRET);
+  if (!verification.valid) return null;
+  return verification.payload;
+}
+
+function parsePage(value) {
+  const page = Number(value);
+  return Number.isFinite(page) && page > 0 ? Math.floor(page) : 1;
+}
+
+function parseLimit(value) {
+  const limit = Number(value);
+  if (!Number.isFinite(limit) || limit <= 0) return 20;
+  return Math.min(Math.floor(limit), 100);
+}
+
+export async function GET(request) {
+  try {
+    const user = await getUserFromCookie(request);
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const buyerAddress = user.walletAddress || user.address || user.id;
+    if (!buyerAddress) {
+      return NextResponse.json({ error: "No wallet address on account" }, { status: 400 });
+    }
+
+    const { searchParams } = new URL(request.url);
+    const page = parsePage(searchParams.get("page"));
+    const limit = parseLimit(searchParams.get("limit"));
+
+    const db = await getDb();
+    const skip = (page - 1) * limit;
+
+    const [purchases, purchaseTotal, onchain] = await Promise.all([
+      db
+        .collection("purchases")
+        .find({ buyerAddress: String(buyerAddress).toLowerCase() })
+        .sort({ purchasedAt: -1, createdAt: -1, updatedAt: -1 })
+        .skip(skip)
+        .limit(limit)
+        .toArray(),
+      db.collection("purchases").countDocuments({ buyerAddress: String(buyerAddress).toLowerCase() }),
+      fetchHorizonTransactions(String(buyerAddress), { page, limit }),
+    ]);
+
+    const purchaseRecords = buildPurchaseHistoryRecords(purchases);
+    const combined = [...purchaseRecords, ...onchain.records].sort((a, b) => {
+      const left = new Date(a.createdAt || 0).getTime();
+      const right = new Date(b.createdAt || 0).getTime();
+      return right - left;
+    });
+
+    return NextResponse.json({
+      page,
+      limit,
+      hasMore: purchaseTotal > page * limit || onchain.hasMore,
+      totals: {
+        purchases: purchaseTotal,
+      },
+      records: combined,
+    });
+  } catch (error) {
+    console.error("Transaction history error:", error);
+    return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+  }
+}

--- a/src/lib/transactions/historyFeed.js
+++ b/src/lib/transactions/historyFeed.js
@@ -1,0 +1,83 @@
+const DEFAULT_CACHE_TTL_MS = 60_000;
+const HORIZON_BASE_URL =
+  process.env.NEXT_PUBLIC_STELLAR_NETWORK === "PUBLIC"
+    ? "https://horizon.stellar.org"
+    : "https://horizon-testnet.stellar.org";
+
+function getCacheStore() {
+  if (!globalThis.__eduvaultHistoryCache) {
+    globalThis.__eduvaultHistoryCache = new Map();
+  }
+  return globalThis.__eduvaultHistoryCache;
+}
+
+function readCache(key, now = Date.now()) {
+  const cache = getCacheStore();
+  const record = cache.get(key);
+  if (!record) return null;
+  if (record.expiresAt <= now) {
+    cache.delete(key);
+    return null;
+  }
+  return record.value;
+}
+
+function writeCache(key, value, ttlMs = DEFAULT_CACHE_TTL_MS, now = Date.now()) {
+  getCacheStore().set(key, { value, expiresAt: now + ttlMs });
+}
+
+function normalizeOnchainTransaction(tx) {
+  return {
+    id: tx.id || tx.hash,
+    hash: tx.hash,
+    sourceAccount: tx.source_account,
+    ledger: tx.ledger_attr || tx.ledger || null,
+    successful: tx.successful,
+    createdAt: tx.created_at,
+    operationCount: tx.operation_count ?? null,
+    feeCharged: tx.fee_charged ?? null,
+    memoType: tx.memo_type ?? null,
+    memo: tx.memo ?? null,
+    type: "onchain_transaction",
+  };
+}
+
+export async function fetchHorizonTransactions(address, { page = 1, limit = 20 } = {}) {
+  const safePage = Number.isFinite(page) && page > 0 ? Math.floor(page) : 1;
+  const safeLimit = Number.isFinite(limit) && limit > 0 ? Math.min(Math.floor(limit), 100) : 20;
+  const cacheKey = `${address}:${safePage}:${safeLimit}`;
+  const cached = readCache(cacheKey);
+  if (cached) return cached;
+
+  const horizonLimit = safePage * safeLimit;
+  const url = `${HORIZON_BASE_URL}/accounts/${encodeURIComponent(address)}/transactions?order=desc&limit=${horizonLimit}`;
+  const response = await fetch(url, { cache: "no-store" });
+  if (!response.ok) {
+    throw new Error(`Horizon request failed (${response.status})`);
+  }
+
+  const payload = await response.json();
+  const allRecords = payload?._embedded?.records || [];
+  const start = (safePage - 1) * safeLimit;
+  const paginated = allRecords.slice(start, start + safeLimit).map(normalizeOnchainTransaction);
+  const result = {
+    records: paginated,
+    hasMore: allRecords.length > start + safeLimit,
+  };
+  writeCache(cacheKey, result);
+  return result;
+}
+
+export function buildPurchaseHistoryRecords(purchases) {
+  return purchases.map((purchase) => ({
+    id: String(purchase._id),
+    hash: purchase.transactionHash || purchase.chainTxHash || null,
+    materialId: purchase.materialId || null,
+    status: purchase.status || null,
+    amount: purchase.amount ?? null,
+    asset: purchase.asset ?? null,
+    source: "database",
+    createdAt: purchase.purchasedAt || purchase.updatedAt || purchase.createdAt || null,
+    type: "purchase_record",
+  }));
+}


### PR DESCRIPTION
## Summary
- add a new paginated transaction history API that merges MongoDB purchase records with cached Horizon account transactions
- add explicit paused material state handling, creator/admin authorization for state toggles, and material status changed event emission in the material registry contract
- enforce paused-material purchase rejection in purchase manager logic and expand contract test coverage/docs for the new behavior

## Verification
- Tests not run (skipped by request)
- verified commit author/committer identity with: `git log --format='%h %an <%ae> | %cn <%ce>' -10`

Closes #79
Closes #125

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a unified transaction history endpoint that displays paginated combined records of purchases and blockchain transactions.
  * Added the ability to pause and unpause materials with individual status tracking.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Obiajulu-gif/eduvault/pull/163?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->