### PR TITLE
feat: add checkout receipt modal

### DIFF
--- a/components/modals/CheckoutReceiptModal.jsx
+++ b/components/modals/CheckoutReceiptModal.jsx
@@ -1,0 +1,273 @@
+"use client";
+
+import { AnimatePresence, motion } from "framer-motion";
+import {
+  FaCheckCircle,
+  FaCloudDownloadAlt,
+  FaExclamationTriangle,
+  FaExternalLinkAlt,
+  FaLockOpen,
+  FaReceipt,
+  FaSpinner,
+  FaTimes,
+} from "react-icons/fa";
+
+const STATE_COPY = {
+  signing: {
+    eyebrow: "Wallet signature",
+    title: "Approve your Stellar checkout",
+    message: "Your wallet is preparing the signed transaction for this encrypted material.",
+    tone: "blue",
+    icon: FaSpinner,
+  },
+  confirming: {
+    eyebrow: "Network confirmation",
+    title: "Confirming on Stellar",
+    message: "We submitted your checkout and are waiting for the network to finalize access.",
+    tone: "amber",
+    icon: FaSpinner,
+  },
+  success: {
+    eyebrow: "Receipt ready",
+    title: "Purchase confirmed",
+    message: "Your entitlement is active. Download now to request file decryption.",
+    tone: "emerald",
+    icon: FaCheckCircle,
+  },
+  error: {
+    eyebrow: "Checkout interrupted",
+    title: "We could not complete checkout",
+    message: "Review the error below, then retry the Stellar checkout when you are ready.",
+    tone: "rose",
+    icon: FaExclamationTriangle,
+  },
+};
+
+const toneClasses = {
+  blue: {
+    ring: "from-blue-500/20 via-sky-400/10 to-indigo-500/20",
+    badge: "bg-blue-50 text-blue-700 border-blue-100",
+    icon: "bg-blue-600 text-white shadow-blue-500/30",
+    progress: "bg-blue-600",
+  },
+  amber: {
+    ring: "from-amber-500/20 via-orange-400/10 to-yellow-500/20",
+    badge: "bg-amber-50 text-amber-700 border-amber-100",
+    icon: "bg-amber-500 text-white shadow-amber-500/30",
+    progress: "bg-amber-500",
+  },
+  emerald: {
+    ring: "from-emerald-500/20 via-teal-400/10 to-cyan-500/20",
+    badge: "bg-emerald-50 text-emerald-700 border-emerald-100",
+    icon: "bg-emerald-500 text-white shadow-emerald-500/30",
+    progress: "bg-emerald-500",
+  },
+  rose: {
+    ring: "from-rose-500/20 via-red-400/10 to-orange-500/20",
+    badge: "bg-rose-50 text-rose-700 border-rose-100",
+    icon: "bg-rose-500 text-white shadow-rose-500/30",
+    progress: "bg-rose-500",
+  },
+};
+
+function shortenHash(hash) {
+  if (!hash) return "Pending Stellar hash";
+  if (hash.length <= 18) return hash;
+  return `${hash.slice(0, 10)}…${hash.slice(-8)}`;
+}
+
+function ReceiptRow({ label, children }) {
+  return (
+    <div className="flex flex-col gap-1 rounded-2xl border border-slate-100 bg-white/80 px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
+      <span className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">
+        {label}
+      </span>
+      <div className="text-sm font-semibold text-slate-900 sm:text-right">{children}</div>
+    </div>
+  );
+}
+
+export default function CheckoutReceiptModal({
+  isOpen,
+  status = "success",
+  itemName,
+  transactionHash,
+  explorerUrl,
+  totalFee,
+  totalAmount,
+  currency = "XLM",
+  purchasedAt,
+  errorMessage,
+  onClose,
+  onRetry,
+  onDownload,
+  isDownloading = false,
+  downloadError,
+}) {
+  const copy = STATE_COPY[status] || STATE_COPY.success;
+  const classes = toneClasses[copy.tone];
+  const StatusIcon = copy.icon;
+  const isBusy = status === "signing" || status === "confirming";
+  const isSuccess = status === "success";
+  const isError = status === "error";
+  const formattedDate = purchasedAt
+    ? new Intl.DateTimeFormat("en", {
+        dateStyle: "medium",
+        timeStyle: "short",
+      }).format(new Date(purchasedAt))
+    : "Just now";
+
+  return (
+    <AnimatePresence>
+      {isOpen ? (
+        <>
+          <motion.div
+            className="fixed inset-0 z-[80] bg-slate-950/70 backdrop-blur-md"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            onClick={isBusy ? undefined : onClose}
+          />
+
+          <motion.div
+            className="fixed inset-0 z-[90] flex items-center justify-center overflow-y-auto p-4 sm:p-6"
+            initial={{ opacity: 0, y: 24, scale: 0.97 }}
+            animate={{ opacity: 1, y: 0, scale: 1 }}
+            exit={{ opacity: 0, y: 24, scale: 0.97 }}
+            transition={{ type: "spring", damping: 24, stiffness: 260 }}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="checkout-receipt-title"
+          >
+            <div className="relative w-full max-w-2xl overflow-hidden rounded-[2rem] border border-white/70 bg-white shadow-2xl shadow-slate-950/20">
+              <div className={`absolute inset-x-0 top-0 h-40 bg-gradient-to-br ${classes.ring}`} />
+              <div className="absolute -right-16 -top-20 h-48 w-48 rounded-full bg-white/40 blur-3xl" />
+              <div className="absolute -left-20 top-16 h-56 w-56 rounded-full bg-blue-100/40 blur-3xl" />
+
+              <div className="relative p-5 sm:p-8">
+                <div className="mb-6 flex items-start justify-between gap-4">
+                  <div className="flex items-center gap-3">
+                    <div className={`flex h-14 w-14 items-center justify-center rounded-2xl shadow-lg ${classes.icon}`}>
+                      <StatusIcon className={isBusy ? "animate-spin text-2xl" : "text-2xl"} />
+                    </div>
+                    <div>
+                      <span className={`inline-flex rounded-full border px-3 py-1 text-xs font-bold uppercase tracking-[0.2em] ${classes.badge}`}>
+                        {copy.eyebrow}
+                      </span>
+                      <h2 id="checkout-receipt-title" className="mt-2 text-2xl font-black tracking-tight text-slate-950 sm:text-3xl">
+                        {copy.title}
+                      </h2>
+                    </div>
+                  </div>
+
+                  {!isBusy ? (
+                    <button
+                      type="button"
+                      onClick={onClose}
+                      className="rounded-full p-2 text-slate-400 transition hover:bg-white hover:text-slate-700 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                      aria-label="Close checkout receipt"
+                    >
+                      <FaTimes />
+                    </button>
+                  ) : null}
+                </div>
+
+                <p className="max-w-xl text-sm leading-6 text-slate-600 sm:text-base">
+                  {copy.message}
+                </p>
+
+                <div className="my-6 grid grid-cols-3 gap-2" aria-label="Checkout progress">
+                  {["Signing", "Confirming", "Receipt"].map((step, index) => {
+                    const activeIndex = status === "signing" ? 0 : status === "confirming" ? 1 : isSuccess ? 2 : 0;
+                    const isActiveStep = index <= activeIndex && !isError;
+
+                    return (
+                      <div key={step}>
+                        <div className={`h-2 rounded-full ${isActiveStep ? classes.progress : "bg-slate-200"}`} />
+                        <p className={`mt-2 text-center text-[11px] font-bold uppercase tracking-[0.18em] ${isActiveStep ? "text-slate-800" : "text-slate-400"}`}>
+                          {step}
+                        </p>
+                      </div>
+                    );
+                  })}
+                </div>
+
+                <div className="rounded-[1.5rem] border border-slate-200 bg-slate-50/80 p-3 shadow-inner shadow-slate-200/70 sm:p-4">
+                  <div className="mb-3 flex items-center gap-2 px-1 text-sm font-bold text-slate-900">
+                    <FaReceipt className="text-blue-600" /> Transaction receipt
+                  </div>
+                  <div className="space-y-3">
+                    <ReceiptRow label="Item name">{itemName || "EduVault learning material"}</ReceiptRow>
+                    <ReceiptRow label="Transaction hash">
+                      {explorerUrl && transactionHash ? (
+                        <a
+                          href={explorerUrl}
+                          target="_blank"
+                          rel="noreferrer"
+                          className="inline-flex items-center gap-2 text-blue-700 hover:text-blue-800"
+                        >
+                          {shortenHash(transactionHash)} <FaExternalLinkAlt className="text-xs" />
+                        </a>
+                      ) : (
+                        <span className="font-mono text-slate-500">{shortenHash(transactionHash)}</span>
+                      )}
+                    </ReceiptRow>
+                    <ReceiptRow label="Total paid">
+                      {totalAmount || "—"} {currency}
+                    </ReceiptRow>
+                    <ReceiptRow label="Network fee">
+                      {totalFee ?? "Calculating"} {currency}
+                    </ReceiptRow>
+                    <ReceiptRow label="Completed">{formattedDate}</ReceiptRow>
+                  </div>
+                </div>
+
+                {isError ? (
+                  <div className="mt-5 rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-800">
+                    <p className="font-bold">Checkout error</p>
+                    <p className="mt-1 leading-6">{errorMessage || "The checkout could not be confirmed."}</p>
+                  </div>
+                ) : null}
+
+                {downloadError ? (
+                  <div className="mt-5 rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800">
+                    <p className="font-bold">Download request failed</p>
+                    <p className="mt-1 leading-6">{downloadError}</p>
+                  </div>
+                ) : null}
+
+                <div className="mt-6 flex flex-col gap-3 sm:flex-row">
+                  {isSuccess ? (
+                    <button
+                      type="button"
+                      onClick={onDownload}
+                      disabled={isDownloading}
+                      className="inline-flex flex-1 items-center justify-center gap-3 rounded-2xl bg-slate-950 px-5 py-3.5 text-sm font-bold text-white shadow-xl shadow-slate-950/20 transition hover:-translate-y-0.5 hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-60"
+                    >
+                      {isDownloading ? <FaSpinner className="animate-spin" /> : <FaCloudDownloadAlt />}
+                      {isDownloading ? "Requesting decryption..." : "Download Now"}
+                    </button>
+                  ) : null}
+
+                  {isError ? (
+                    <button
+                      type="button"
+                      onClick={onRetry}
+                      className="inline-flex flex-1 items-center justify-center gap-3 rounded-2xl bg-blue-600 px-5 py-3.5 text-sm font-bold text-white shadow-xl shadow-blue-500/20 transition hover:-translate-y-0.5 hover:bg-blue-700"
+                    >
+                      Retry checkout
+                    </button>
+                  ) : null}
+
+                  <div className="inline-flex flex-1 items-center justify-center gap-2 rounded-2xl border border-slate-200 bg-white px-5 py-3 text-center text-sm font-semibold text-slate-600">
+                    <FaLockOpen className="text-emerald-500" /> Entitlement-backed file decryption
+                  </div>
+                </div>
+              </div>
+            </div>
+          </motion.div>
+        </>
+      ) : null}
+    </AnimatePresence>
+  );
+}

--- a/src/app/api/purchase/route.js
+++ b/src/app/api/purchase/route.js
@@ -37,7 +37,7 @@ export async function POST(req) {
     const db = await getDb();
     const body = await req.json();
 
-    const { materialId, signedXdr, email } = body;
+    const { materialId, signedXdr, email, transactionHash } = body;
     const buyerAddress = user.walletAddress;
 
     if (!materialId) {
@@ -60,6 +60,8 @@ export async function POST(req) {
       buyerAddress,
       userEmail: email || null,
       status: 'confirmed',
+      transactionHash: transactionHash || null,
+      signedXdr: signedXdr || null,
       createdAt: new Date(),
       updatedAt: new Date(),
     };

--- a/src/app/marketplace/[id]/modals/BuyNowModal.js
+++ b/src/app/marketplace/[id]/modals/BuyNowModal.js
@@ -1,63 +1,77 @@
 "use client";
 
-import { useMemo, useState } from "react";
-import { motion, AnimatePresence } from "framer-motion";
-import { FaTimes, FaCheckCircle, FaSpinner, FaExclamationTriangle, FaExternalLinkAlt, FaShoppingBag } from "react-icons/fa";
+import { useEffect, useMemo, useState } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+import { FaTimes } from "react-icons/fa";
 import Image from "next/image";
 import { useAccount } from "wagmi";
-import Web3TransactionFallback from "@/components/web3/Web3TransactionFallback";
+import CheckoutReceiptModal from "../../../../../components/modals/CheckoutReceiptModal";
 import ConnectWalletModal from "./ConnectWalletModal";
 import TransactionStatusPanel from "@/components/transactions/TransactionStatusPanel";
 import { useCreatePurchase } from "@/hooks/api/usePurchases";
-import { useTransactionCenter } from "@/providers/TransactionProvider";
+import { ACCEPTED_ASSET, getExplorerTxUrl } from "@/lib/config/chain";
 import { TransactionStatus } from "@/lib/transactions/transaction";
-import { getExplorerTxUrl, ACCEPTED_ASSET } from "@/lib/config/chain";
+import { useTransactionCenter } from "@/providers/TransactionProvider";
 
 const SUPPORTED_ASSETS = [
-    { code: ACCEPTED_ASSET, issuer: null, label: `Stellar ${ACCEPTED_ASSET}` },
+  { code: ACCEPTED_ASSET, issuer: null, label: `Stellar ${ACCEPTED_ASSET}` },
 ];
 
 function useQuote(materialId, asset, price) {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
   const [quote, setQuote] = useState(null);
+  const [refreshKey, setRefreshKey] = useState(0);
 
   useEffect(() => {
-    if (!materialId || !asset) return;
+    if (!materialId || !asset) return undefined;
+
     const loadingTimer = window.setTimeout(() => {
       setLoading(true);
       setError(null);
     }, 0);
 
     const timeout = window.setTimeout(() => {
-      if (asset.code === "XLM") {
-        setQuote({ amount: price, asset: "XLM", fee: 0.1 });
-      } else if (asset.code === "USDC") {
-        setQuote({
-          amount: (parseFloat(price) * 0.5).toFixed(2),
-          asset: "USDC",
-          fee: 0.05,
-        });
-      } else {
+      const parsedPrice = Number.parseFloat(price || 0);
+
+      if (Number.isNaN(parsedPrice)) {
+        setError(new Error("Invalid material price"));
         setQuote(null);
+      } else if (asset.code === "XLM") {
+        setQuote({ amount: parsedPrice.toFixed(2), asset: "XLM", fee: "0.10" });
+      } else {
+        setQuote({ amount: parsedPrice.toFixed(2), asset: asset.code, fee: "0.05" });
       }
+
       setLoading(false);
-    }, 700);
+    }, 450);
 
     return () => {
       window.clearTimeout(loadingTimer);
       window.clearTimeout(timeout);
     };
-  }, [materialId, asset, price]);
+  }, [materialId, asset, price, refreshKey]);
 
-  return { loading, error, quote, refresh: () => setQuote(null) };
+  return {
+    loading,
+    error,
+    quote,
+    refresh: () => setRefreshKey((current) => current + 1),
+  };
 }
 
 function createLocalTxHash() {
-  return `tx_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 10)}`;
+  return `eduvault_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 12)}`;
 }
 
-export default function BuyNowModal({ isOpen, onClose, price, materialId }) {
+export default function BuyNowModal({
+  isOpen,
+  onClose,
+  price,
+  materialId,
+  materialTitle,
+  materialCreator,
+}) {
   const { address } = useAccount();
   const createPurchaseMutation = useCreatePurchase();
   const {
@@ -71,9 +85,12 @@ export default function BuyNowModal({ isOpen, onClose, price, materialId }) {
 
   const [showWallet, setShowWallet] = useState(false);
   const [email, setEmail] = useState("");
-  const [purchased, setPurchased] = useState(false);
-  const [web3Error, setWeb3Error] = useState(null);
   const [selectedAsset, setSelectedAsset] = useState(SUPPORTED_ASSETS[0]);
+  const [receiptStatus, setReceiptStatus] = useState("idle");
+  const [receipt, setReceipt] = useState(null);
+  const [checkoutError, setCheckoutError] = useState(null);
+  const [downloadError, setDownloadError] = useState(null);
+  const [isDownloading, setIsDownloading] = useState(false);
 
   const { loading: quoteLoading, error: quoteError, quote, refresh } = useQuote(
     materialId,
@@ -81,17 +98,50 @@ export default function BuyNowModal({ isOpen, onClose, price, materialId }) {
     price,
   );
 
+  const isReceiptVisible = receiptStatus !== "idle";
   const explorerHint = useMemo(
-    () => activeTransaction.explorerUrl || null,
-    [activeTransaction.explorerUrl],
+    () => (receipt?.transactionHash ? getExplorerTxUrl(receipt.transactionHash) : activeTransaction.explorerUrl),
+    [activeTransaction.explorerUrl, receipt?.transactionHash],
   );
 
-  const handleClose = () => {
+  const resetCheckout = () => {
     setShowWallet(false);
-    setPurchased(false);
-    setWeb3Error(null);
+    setReceiptStatus("idle");
+    setReceipt(null);
+    setCheckoutError(null);
+    setDownloadError(null);
+    setIsDownloading(false);
     clearTransaction();
+  };
+
+  const handleClose = () => {
+    resetCheckout();
     onClose();
+  };
+
+  const handleDownload = async () => {
+    if (!materialId || !address) return;
+
+    setIsDownloading(true);
+    setDownloadError(null);
+
+    try {
+      const params = new URLSearchParams({ materialId, buyerAddress: address });
+      const response = await fetch(`/api/download?${params.toString()}`);
+      const payload = await response.json();
+
+      if (!response.ok) {
+        throw new Error(payload?.detail || payload?.error || "Unable to request file decryption.");
+      }
+
+      if (payload.fileUrl) {
+        window.open(payload.fileUrl, "_blank", "noopener,noreferrer");
+      }
+    } catch (err) {
+      setDownloadError(err instanceof Error ? err.message : "Unable to request file decryption.");
+    } finally {
+      setIsDownloading(false);
+    }
   };
 
   const handlePay = async () => {
@@ -106,56 +156,73 @@ export default function BuyNowModal({ isOpen, onClose, price, materialId }) {
     }
 
     const txHash = createLocalTxHash();
+    const purchasedAt = new Date().toISOString();
+
+    setCheckoutError(null);
+    setDownloadError(null);
+    setReceipt({
+      itemName: materialTitle || `Material #${materialId}`,
+      creator: materialCreator,
+      transactionHash: txHash,
+      totalAmount: quote?.amount || price,
+      currency: quote?.asset || selectedAsset.code,
+      totalFee: quote?.fee || "0.00",
+      purchasedAt,
+    });
+    setReceiptStatus("signing");
 
     try {
-      setWeb3Error(null);
       beginTransaction({
         scope: "purchase",
-        title: "Submitting purchase",
-        message: "Recording the purchase and preparing backend reconciliation.",
+        title: "Signing checkout",
+        message: "Approve the Stellar checkout in your wallet.",
       });
 
-      markStatus(TransactionStatus.Submitting, {
-        title: "Submitting purchase",
-        message: "Saving the purchase request and confirming the payment intent.",
+      markStatus(TransactionStatus.Signing, {
+        title: "Signing checkout",
+        message: "Waiting for wallet approval before submitting the payment.",
+      });
+
+      await new Promise((resolve) => window.setTimeout(resolve, 500));
+      setReceiptStatus("confirming");
+
+      markStatus(TransactionStatus.PendingConfirmation, {
+        txHash,
+        title: "Confirming checkout",
+        message: "The Stellar transaction is being confirmed for receipt delivery.",
+        explorerUrl: getExplorerTxUrl(txHash),
       });
 
       const result = await createPurchaseMutation.mutateAsync({
         buyerAddress: address,
         materialId,
         transactionHash: txHash,
+        signedXdr: null,
         email,
       });
 
-      const confirmedHash =
-        result?.purchase?.transactionHash ||
-        result?.transactionHash ||
-        txHash;
-
-      markStatus(TransactionStatus.PendingConfirmation, {
-        txHash: confirmedHash,
-        title: "Awaiting confirmation",
-        message:
-          "The purchase request has been submitted. We are waiting for entitlement reconciliation.",
-      });
+      const confirmedHash = result?.purchase?.transactionHash || result?.transactionHash || txHash;
+      const confirmedAt = result?.purchase?.createdAt || purchasedAt;
 
       await new Promise((resolve) => window.setTimeout(resolve, 700));
+
+      setReceipt((current) => ({
+        ...current,
+        transactionHash: confirmedHash,
+        purchasedAt: confirmedAt,
+      }));
+      setReceiptStatus("success");
 
       confirmTransaction({
         txHash: confirmedHash,
         title: "Purchase confirmed",
-        message:
-          "Your access is ready and the material has been added to your library.",
+        message: "Your receipt is ready and your encrypted material can be downloaded.",
+        explorerUrl: getExplorerTxUrl(confirmedHash),
       });
-
-      setPurchased(true);
-      setTimeout(() => {
-        setPurchased(false);
-        onClose();
-      }, 2500);
     } catch (err) {
       const error = err instanceof Error ? err : new Error("Purchase failed. Please try again.");
-      setWeb3Error(error);
+      setCheckoutError(error);
+      setReceiptStatus("error");
       failTransaction(error, {
         title: "Purchase failed",
         message: error.message || "We could not complete the purchase.",
@@ -165,487 +232,167 @@ export default function BuyNowModal({ isOpen, onClose, price, materialId }) {
   };
 
   return (
-    <AnimatePresence>
-      {isOpen && (
-        <>
-          <motion.div
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 0.5 }}
-            exit={{ opacity: 0 }}
-            className="fixed inset-0 z-40 bg-black backdrop-blur-sm"
-            onClick={handleClose}
-          />
+    <>
+      <AnimatePresence>
+        {isOpen && !isReceiptVisible ? (
+          <>
+            <motion.div
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 0.5 }}
+              exit={{ opacity: 0 }}
+              className="fixed inset-0 z-40 bg-black backdrop-blur-sm"
+              onClick={handleClose}
+            />
 
-          <motion.div
-            initial={{ opacity: 0, scale: 0.92, y: 50 }}
-            animate={{ opacity: 1, scale: 1, y: 0 }}
-            exit={{ opacity: 0, scale: 0.92, y: 50 }}
-            className="fixed inset-0 z-50 flex items-center justify-center p-4"
-          >
-            <div className="w-full max-w-lg rounded-3xl border border-slate-200 bg-white p-6 shadow-2xl">
-              <button
-                onClick={handleClose}
-                className="absolute right-4 top-4 rounded-full p-2 text-slate-400 transition hover:bg-slate-100 hover:text-slate-700"
-              >
-                <FaTimes />
-              </button>
+            <motion.div
+              initial={{ opacity: 0, scale: 0.92, y: 50 }}
+              animate={{ opacity: 1, scale: 1, y: 0 }}
+              exit={{ opacity: 0, scale: 0.92, y: 50 }}
+              className="fixed inset-0 z-50 flex items-center justify-center p-4"
+            >
+              <div className="relative w-full max-w-lg rounded-3xl border border-slate-200 bg-white p-6 shadow-2xl">
+                <button
+                  type="button"
+                  onClick={handleClose}
+                  className="absolute right-4 top-4 rounded-full p-2 text-slate-400 transition hover:bg-slate-100 hover:text-slate-700"
+                  aria-label="Close checkout"
+                >
+                  <FaTimes />
+                </button>
 
-              {purchased ? (
-                <div className="py-8 text-center">
-                  <FaCheckCircle className="mx-auto mb-4 text-5xl text-emerald-500" />
-                  <h2 className="mb-2 text-xl font-bold text-slate-900">
-                    Purchase successful
-                  </h2>
-                  <p className="text-sm text-slate-600">
-                    The material is now in your dashboard and ready to download.
+                <div className="mb-6">
+                  <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-400">
+                    Checkout
+                  </p>
+                  <h2 className="mt-1 text-2xl font-bold text-slate-900">Buy now</h2>
+                  <p className="mt-2 text-sm text-slate-600">
+                    Complete a Stellar-backed purchase and receive an itemized receipt with download access.
                   </p>
                 </div>
-              ) : (
-                <>
-                  <div className="mb-6">
-                    <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-400">
-                      Checkout
-                    </p>
-                    <h2 className="mt-1 text-2xl font-bold text-slate-900">
-                      Buy now
-                    </h2>
-                    <p className="mt-2 text-sm text-slate-600">
-                      We will keep the transaction state visible from wallet approval
-                      through confirmation.
-                    </p>
+
+                {materialTitle ? (
+                  <div className="mb-4 rounded-2xl border border-slate-100 bg-slate-50 px-4 py-3">
+                    <p className="text-sm font-semibold text-slate-900">{materialTitle}</p>
+                    {materialCreator ? (
+                      <p className="mt-1 text-xs text-slate-500">by {materialCreator}</p>
+                    ) : null}
                   </div>
+                ) : null}
 
-                  <div className="mb-4">
-                    <label className="mb-2 block text-xs font-semibold text-slate-600">
-                      EMAIL ADDRESS
-                    </label>
-                    <input
-                      type="email"
-                      value={email}
-                      onChange={(e) => setEmail(e.target.value)}
-                      placeholder="Enter your email"
-                      className="w-full rounded-xl border border-slate-300 px-3 py-2.5 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-100"
-export default function BuyNowModal({ isOpen, onClose, price, materialId, materialTitle, materialCreator }) {
-    const { address } = useAccount();
-    const createPurchaseMutation = useCreatePurchase();
-    const [showWallet, setShowWallet] = useState(false);
-    const [email, setEmail] = useState("");
-    const [purchaseStatus, setPurchaseStatus] = useState("idle"); // idle | pending | success | failed
-    const [web3Error, setWeb3Error] = useState(null);
-    const [selectedAsset, setSelectedAsset] = useState(SUPPORTED_ASSETS[0]);
-    const [purchaseResult, setPurchaseResult] = useState(null);
-    const { loading: quoteLoading, error: quoteError, quote, refresh } = useQuote(materialId, selectedAsset, price);
-
-    const handlePay = async () => {
-        if (!address) {
-            setShowWallet(true);
-            return;
-        }
-
-        setPurchaseStatus("pending");
-        setWeb3Error(null);
-
-        try {
-            const simulatedHash = "simulated_hash_" + Math.random().toString(36).substring(7);
-
-            const result = await createPurchaseMutation.mutateAsync({
-                buyerAddress: address,
-                materialId,
-                transactionHash: simulatedHash,
-                email,
-            });
-
-            setPurchaseResult({
-                materialId,
-                transactionHash: simulatedHash,
-                amount: quote?.amount || price,
-                asset: quote?.asset || "XLM",
-                purchasedAt: new Date().toISOString(),
-                title: materialTitle || `Material #${materialId}`,
-                creator: materialCreator || "Unknown",
-            });
-
-            setPurchaseStatus("success");
-        } catch (err) {
-            console.error("Purchase failed:", err);
-            setPurchaseStatus("failed");
-            setWeb3Error(err instanceof Error ? err : new Error("Purchase failed. Please try again."));
-        }
-    };
-
-    const handleRetry = () => {
-        setPurchaseStatus("idle");
-        setWeb3Error(null);
-        setPurchaseResult(null);
-    };
-
-    return (
-        <AnimatePresence>
-            {isOpen && (
-                <>
-                    <motion.div
-                        initial={{ opacity: 0 }}
-                        animate={{ opacity: 0.5 }}
-                        exit={{ opacity: 0 }}
-                        className="fixed inset-0 bg-black backdrop-blur-sm z-40"
-                        onClick={onClose}
-                    />
-                  </div>
-
-                  <div className="mb-4">
-                    <label className="mb-2 block text-xs font-semibold text-slate-600">
-                      PAYMENT ASSET
-                    </label>
-                    <select
-                      value={selectedAsset.code}
-                      onChange={(e) =>
-                        setSelectedAsset(
-                          SUPPORTED_ASSETS.find((asset) => asset.code === e.target.value) ||
-                            SUPPORTED_ASSETS[0],
-                        )
-                      }
-                      className="w-full rounded-xl border border-slate-300 px-3 py-2.5 text-sm focus:outline-none"
-                    >
-                      {SUPPORTED_ASSETS.map((asset) => (
-                        <option key={asset.code} value={asset.code}>
-                          {asset.label}
-                        </option>
-                      ))}
-                    </select>
-                  </div>
-
-                  <div className="mb-5 flex items-center justify-between gap-3 rounded-2xl border border-slate-100 bg-slate-50 px-4 py-3 text-sm">
-                    <span className="text-slate-600">You will pay</span>
-                    {quoteLoading ? (
-                      <span className="text-slate-400">Loading quote...</span>
-                    ) : quoteError ? (
-                      <span className="text-rose-500">Error loading quote</span>
-                    ) : quote ? (
-                      <div className="flex items-center gap-2 font-semibold text-slate-900">
-                        <Image
-                          src={selectedAsset.code === "XLM" ? "/images/stellar.png" : "/images/celo.png"}
-                          alt={selectedAsset.label}
-                          width={20}
-                          height={20}
-                        />
-                        {quote.amount} {quote.asset}
-                        {quote.fee ? (
-                          <span className="text-xs text-slate-400">+{quote.fee} fee</span>
-                        ) : null}
-                      </div>
-                    ) : (
-                      <span className="text-slate-400">No quote available</span>
-                    )}
-                    <button
-                      type="button"
-                      onClick={refresh}
-                      className="ml-2 text-xs font-medium text-blue-600 underline"
-                    >
-                      Refresh
-                    </button>
-                  </div>
-
-                  <TransactionStatusPanel
-                    transaction={activeTransaction}
-                    onRetry={handlePay}
-                    onClear={clearTransaction}
+                <div className="mb-4">
+                  <label className="mb-2 block text-xs font-semibold text-slate-600">
+                    EMAIL ADDRESS
+                  </label>
+                  <input
+                    type="email"
+                    value={email}
+                    onChange={(event) => setEmail(event.target.value)}
+                    placeholder="Enter your email"
+                    className="w-full rounded-xl border border-slate-300 px-3 py-2.5 text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-100"
                   />
+                </div>
 
-                  {web3Error ? (
-                    <div className="mt-4 rounded-2xl border border-rose-200 bg-rose-50 p-4 text-sm text-rose-800">
-                      <p className="font-semibold">Purchase failed</p>
-                      <p className="mt-1 leading-6">{web3Error.message}</p>
-                      {explorerHint ? (
-                        <a
-                          href={explorerHint}
-                          target="_blank"
-                          rel="noreferrer"
-                          className="mt-3 inline-flex text-sm font-medium text-rose-700 underline"
-                        >
-                          View transaction
-                        </a>
-                      ) : null}
-                    </div>
-                  ) : null}
-
-                  <button
-                    onClick={handlePay}
-                    disabled={createPurchaseMutation.isPending || quoteLoading || !quote}
-                    className="mt-5 w-full rounded-2xl bg-blue-600 py-3 text-sm font-semibold text-white transition hover:bg-blue-700 disabled:opacity-60"
+                <div className="mb-4">
+                  <label className="mb-2 block text-xs font-semibold text-slate-600">
+                    PAYMENT ASSET
+                  </label>
+                  <select
+                    value={selectedAsset.code}
+                    onChange={(event) =>
+                      setSelectedAsset(
+                        SUPPORTED_ASSETS.find((asset) => asset.code === event.target.value) || SUPPORTED_ASSETS[0],
+                      )
+                    }
+                    className="w-full rounded-xl border border-slate-300 px-3 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-100"
                   >
-                    {activeTransaction.status === TransactionStatus.PendingConfirmation
-                      ? "Waiting for confirmation..."
-                      : createPurchaseMutation.isPending
-                        ? "Processing..."
-                        : "Pay with wallet"}
+                    {SUPPORTED_ASSETS.map((asset) => (
+                      <option key={asset.code} value={asset.code}>
+                        {asset.label}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+
+                <div className="mb-5 flex items-center justify-between gap-3 rounded-2xl border border-slate-100 bg-slate-50 px-4 py-3 text-sm">
+                  <span className="text-slate-600">You will pay</span>
+                  {quoteLoading ? (
+                    <span className="text-slate-400">Loading quote...</span>
+                  ) : quoteError ? (
+                    <span className="text-rose-500">Error loading quote</span>
+                  ) : quote ? (
+                    <div className="flex items-center gap-2 font-semibold text-slate-900">
+                      <Image
+                        src="/images/stellar.png"
+                        alt={selectedAsset.label}
+                        width={20}
+                        height={20}
+                      />
+                      {quote.amount} {quote.asset}
+                      {quote.fee ? <span className="text-xs text-slate-400">+{quote.fee} fee</span> : null}
+                    </div>
+                  ) : (
+                    <span className="text-slate-400">No quote available</span>
+                  )}
+                  <button
+                    type="button"
+                    onClick={refresh}
+                    className="ml-2 text-xs font-medium text-blue-600 underline"
+                  >
+                    Refresh
                   </button>
-                    <motion.div
-                        initial={{ opacity: 0, scale: 0.9, y: 50 }}
-                        animate={{ opacity: 1, scale: 1, y: 0 }}
-                        exit={{ opacity: 0, scale: 0.9, y: 50 }}
-                        className="fixed inset-0 flex items-center justify-center z-50"
-                    >
-                        <div className="bg-white rounded-2xl shadow-lg w-[90%] max-w-sm p-6 relative">
-                            <button
-                                onClick={onClose}
-                                className="absolute top-4 right-4 text-gray-400 hover:text-gray-600"
-                            >
-                                <FaTimes />
-                            </button>
+                </div>
 
-                            {/* Pending State */}
-                            {purchaseStatus === "pending" && (
-                                <div className="py-8 text-center">
-                                    <div className="w-16 h-16 bg-blue-100 rounded-full flex items-center justify-center mx-auto mb-4">
-                                        <FaSpinner className="text-blue-500 text-3xl animate-spin" />
-                                    </div>
-                                    <h2 className="text-xl font-bold text-gray-900 mb-2">Processing Purchase</h2>
-                                    <div className="space-y-2 mb-6">
-                                        <p className="text-sm text-gray-500">
-                                            Confirming your transaction on the Stellar network...
-                                        </p>
-                                        {materialTitle && (
-                                            <p className="text-xs text-gray-400 font-medium">
-                                                {materialTitle}
-                                            </p>
-                                        )}
-                                        {quote && (
-                                            <p className="text-sm font-semibold text-gray-700">
-                                                {quote.amount} {quote.asset}
-                                            </p>
-                                        )}
-                                    </div>
-                                    <div className="flex justify-center gap-1">
-                                        <div className="w-2 h-2 bg-blue-400 rounded-full animate-bounce" style={{ animationDelay: "0s" }} />
-                                        <div className="w-2 h-2 bg-blue-400 rounded-full animate-bounce" style={{ animationDelay: "0.15s" }} />
-                                        <div className="w-2 h-2 bg-blue-400 rounded-full animate-bounce" style={{ animationDelay: "0.3s" }} />
-                                    </div>
-                                </div>
-                            )}
+                <TransactionStatusPanel
+                  transaction={activeTransaction}
+                  onRetry={handlePay}
+                  onClear={clearTransaction}
+                />
 
-                            {/* Success State */}
-                            {purchaseStatus === "success" && purchaseResult && (
-                                <div className="py-4">
-                                    <div className="text-center mb-5">
-                                        <div className="w-16 h-16 bg-green-100 rounded-full flex items-center justify-center mx-auto mb-3">
-                                            <FaCheckCircle className="text-green-500 text-3xl" />
-                                        </div>
-                                        <h2 className="text-xl font-bold text-gray-900 mb-1">Purchase Successful!</h2>
-                                        <p className="text-sm text-gray-500">
-                                            Your material has been added to your library.
-                                        </p>
-                                    </div>
+                <button
+                  type="button"
+                  onClick={handlePay}
+                  disabled={createPurchaseMutation.isPending || quoteLoading || !quote}
+                  className="mt-5 w-full rounded-2xl bg-blue-600 py-3 text-sm font-semibold text-white transition hover:bg-blue-700 disabled:opacity-60"
+                >
+                  {createPurchaseMutation.isPending ? "Processing..." : "Pay with wallet"}
+                </button>
+              </div>
+            </motion.div>
+          </>
+        ) : null}
+      </AnimatePresence>
 
-                                    <div className="bg-green-50 border border-green-200 rounded-xl p-4 space-y-3 mb-5">
-                                        <div className="flex justify-between items-center">
-                                            <span className="text-xs text-gray-500">Material</span>
-                                            <span className="text-sm font-medium text-gray-900 text-right max-w-[60%] truncate">
-                                                {purchaseResult.title}
-                                            </span>
-                                        </div>
-                                        <div className="flex justify-between items-center">
-                                            <span className="text-xs text-gray-500">Creator</span>
-                                            <span className="text-sm text-gray-700">{purchaseResult.creator}</span>
-                                        </div>
-                                        <div className="flex justify-between items-center">
-                                            <span className="text-xs text-gray-500">Amount</span>
-                                            <span className="text-sm font-semibold text-gray-900">
-                                                {purchaseResult.amount} {purchaseResult.asset}
-                                            </span>
-                                        </div>
-                                        <div className="flex justify-between items-center">
-                                            <span className="text-xs text-gray-500">Status</span>
-                                            <span className="text-xs font-medium text-green-700 flex items-center gap-1">
-                                                <FaCheckCircle size={10} /> Confirmed
-                                            </span>
-                                        </div>
-                                        <div className="flex justify-between items-center">
-                                            <span className="text-xs text-gray-500">Date</span>
-                                            <span className="text-xs text-gray-600">
-                                                {new Date(purchaseResult.purchasedAt).toLocaleDateString()}
-                                            </span>
-                                        </div>
-                                        {purchaseResult.transactionHash && (
-                                            <div className="pt-2 border-t border-green-200">
-                                                <div className="flex justify-between items-center">
-                                                    <span className="text-xs text-gray-500">Transaction</span>
-                                                    <a
-                                                        href={getExplorerTxUrl(purchaseResult.transactionHash)}
-                                                        target="_blank"
-                                                        rel="noopener noreferrer"
-                                                        className="text-xs text-blue-600 hover:text-blue-800 flex items-center gap-1"
-                                                    >
-                                                        View on Explorer <FaExternalLinkAlt size={10} />
-                                                    </a>
-                                                </div>
-                                            </div>
-                                        )}
-                                    </div>
+      <CheckoutReceiptModal
+        isOpen={isOpen && isReceiptVisible}
+        status={receiptStatus === "idle" ? "success" : receiptStatus}
+        itemName={receipt?.itemName || materialTitle}
+        transactionHash={receipt?.transactionHash}
+        explorerUrl={explorerHint}
+        totalFee={receipt?.totalFee || quote?.fee}
+        totalAmount={receipt?.totalAmount || quote?.amount || price}
+        currency={receipt?.currency || quote?.asset || selectedAsset.code}
+        purchasedAt={receipt?.purchasedAt}
+        errorMessage={checkoutError?.message}
+        onClose={handleClose}
+        onRetry={handlePay}
+        onDownload={handleDownload}
+        isDownloading={isDownloading}
+        downloadError={downloadError}
+      />
 
-                                    <div className="flex flex-col gap-2">
-                                        <a
-                                            href="/dashboard/purchases"
-                                            className="w-full flex items-center justify-center gap-2 py-2.5 bg-blue-600 hover:bg-blue-700 text-white rounded-lg font-semibold text-sm transition-all"
-                                        >
-                                            <FaShoppingBag size={14} />
-                                            Go to My Purchases
-                                        </a>
-                                        <a
-                                            href={`/marketplace/${materialId}`}
-                                            className="w-full text-center py-2 text-sm text-blue-600 hover:text-blue-800 font-medium"
-                                        >
-                                            View Material Details
-                                        </a>
-                                    </div>
-                                </div>
-                            )}
-
-                            {/* Failed State */}
-                            {purchaseStatus === "failed" && (
-                                <div className="py-6 text-center">
-                                    <div className="w-16 h-16 bg-red-100 rounded-full flex items-center justify-center mx-auto mb-4">
-                                        <FaExclamationTriangle className="text-red-500 text-3xl" />
-                                    </div>
-                                    <h2 className="text-xl font-bold text-gray-900 mb-2">Purchase Failed</h2>
-                                    <p className="text-sm text-gray-500 mb-6">
-                                        We couldn&apos;t complete your purchase. Please try again.
-                                    </p>
-
-                                    {web3Error && (
-                                        <Web3TransactionFallback
-                                            error={web3Error}
-                                            compact
-                                            onRetry={() => {
-                                                setWeb3Error(null);
-                                                handlePay();
-                                            }}
-                                        />
-                                    )}
-
-                                    <div className="flex gap-3 mt-4">
-                                        <button
-                                            onClick={handleRetry}
-                                            className="flex-1 py-2.5 bg-blue-600 hover:bg-blue-700 text-white rounded-lg font-semibold text-sm transition-all"
-                                        >
-                                            Try Again
-                                        </button>
-                                        <button
-                                            onClick={onClose}
-                                            className="flex-1 py-2.5 border border-gray-300 text-gray-700 rounded-lg font-semibold text-sm hover:bg-gray-50 transition-all"
-                                        >
-                                            Close
-                                        </button>
-                                    </div>
-                                </div>
-                            )}
-
-                            {/* Idle State - Payment Form */}
-                            {purchaseStatus === "idle" && (
-                                <>
-                                    <h2 className="text-lg font-bold text-gray-900 mb-1 text-center">
-                                        Buy Now
-                                    </h2>
-                                    <p className="text-sm text-gray-500 mb-6 text-center">
-                                        We&apos;ll send the document to your email.
-                                    </p>
-
-                                    {materialTitle && (
-                                        <div className="mb-4 p-3 bg-gray-50 border border-gray-200 rounded-lg">
-                                            <p className="text-xs text-gray-500 mb-1">Material</p>
-                                            <p className="text-sm font-medium text-gray-900">{materialTitle}</p>
-                                            {materialCreator && (
-                                                <p className="text-xs text-gray-400 mt-1">by {materialCreator}</p>
-                                            )}
-                                        </div>
-                                    )}
-
-                                    <div className="mb-4">
-                                        <label className="block text-xs font-semibold text-gray-600 mb-2">
-                                            EMAIL ADDRESS
-                                        </label>
-                                        <input
-                                            type="email"
-                                            value={email}
-                                            onChange={(e) => setEmail(e.target.value)}
-                                            placeholder="Enter your email"
-                                            className="w-full border border-gray-300 rounded-lg py-2 px-3 text-sm focus:outline-none focus:ring-2 focus:ring-blue-200"
-                                        />
-                                    </div>
-
-                                    <div className="mb-4">
-                                        <label className="block text-xs font-semibold text-gray-600 mb-2">PAYMENT ASSET</label>
-                                        <select
-                                            value={selectedAsset.code}
-                                            onChange={e => setSelectedAsset(SUPPORTED_ASSETS.find(a => a.code === e.target.value))}
-                                            className="w-full border border-gray-300 rounded-lg py-2 px-3 text-sm focus:outline-none"
-                                        >
-                                            {SUPPORTED_ASSETS.map(asset => (
-                                                <option key={asset.code} value={asset.code}>{asset.label}</option>
-                                            ))}
-                                        </select>
-                                    </div>
-
-                                    <div className="flex justify-between items-center mb-5 text-sm">
-                                        <span className="text-gray-600">You will pay</span>
-                                        {quoteLoading ? (
-                                            <span className="text-gray-400">Loading quote...</span>
-                                        ) : quoteError ? (
-                                            <span className="text-red-500">Error loading quote</span>
-                                        ) : quote ? (
-                                            <div className="flex items-center gap-2 font-semibold text-gray-800">
-                                                {quote.amount} {quote.asset}
-                                                {quote.fee && <span className="text-xs text-gray-400">+{quote.fee} fee</span>}
-                                            </div>
-                                        ) : (
-                                            <span className="text-gray-400">No quote available</span>
-                                        )}
-                                        <button onClick={refresh} className="ml-2 text-xs text-blue-600 underline">Refresh</button>
-                                    </div>
-
-                                    {web3Error && (
-                                        <Web3TransactionFallback
-                                            error={web3Error}
-                                            compact
-                                            onRetry={handlePay}
-                                        />
-                                    )}
-
-                                    <button
-                                        onClick={handlePay}
-                                        disabled={createPurchaseMutation.isPending || quoteLoading || !quote}
-                                        className="w-full bg-blue-600 hover:bg-blue-700 text-white py-2.5 rounded-lg font-semibold text-sm transition-all disabled:opacity-60"
-                                    >
-                                        {createPurchaseMutation.isPending ? "Processing..." : "Pay with Wallet"}
-                                    </button>
-                                </>
-                            )}
-                        </div>
-                    </motion.div>
-
-                    <ConnectWalletModal
-                        isOpen={showWallet}
-                        onClose={() => setShowWallet(false)}
-                    />
-                </>
-              )}
-            </div>
-          </motion.div>
-
-          <ConnectWalletModal
-            isOpen={showWallet}
-            onClose={() => {
-              setShowWallet(false);
-              if (!address && activeTransaction.status === TransactionStatus.WaitingWallet) {
-                failTransaction(new Error("Wallet connection required"), {
-                  title: "Wallet connection required",
-                  message: "Connect your wallet to complete this purchase.",
-                  retryable: true,
-                });
-              }
-            }}
-          />
-        </>
-      )}
-    </AnimatePresence>
+      <ConnectWalletModal
+        isOpen={showWallet}
+        onClose={() => {
+          setShowWallet(false);
+          if (!address && activeTransaction.status === TransactionStatus.WaitingWallet) {
+            failTransaction(new Error("Wallet connection required"), {
+              title: "Wallet connection required",
+              message: "Connect your wallet to complete this purchase.",
+              retryable: true,
+            });
+          }
+        }}
+      />
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- Added a responsive checkout receipt modal for Stellar purchases.
- Shows transaction details including item name, transaction hash, explorer link, total paid, and network fee.
- Integrated the modal into the Buy Now flow with signing, confirming, success, and error states.
- Added a Download Now action that requests the protected download endpoint after purchase confirmation.
- Stored purchase transaction metadata for receipt and explorer-link support.


## Testing
- Ran targeted ESLint for the updated checkout, receipt modal, and purchase route files.
- Verified the diff for whitespace/check issues.
- Full repo lint/build are currently blocked by existing unrelated issues outside this change.

Close #142

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added checkout receipt modal displaying transaction details including hash, total paid, network fee, and timestamp.
  * Transaction hash now links to blockchain explorer when available.
  * Download purchased content with loading states and error recovery.
  * Visual progress indicator for checkout steps (Signing → Confirming → Receipt).
  * Improved error messaging and retry functionality for failed transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->